### PR TITLE
Properly emit team members in the added/removed events

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -157,8 +157,8 @@ export interface BotEvents {
   teamCreated: (team: Team) => Promise<void> | void
   teamRemoved: (team: Team) => Promise<void> | void
   teamUpdated: (team: Team) => Promise<void> | void
-  teamMemberAdded: (team: Team) => Promise<void> | void
-  teamMemberRemoved: (team: Team) => Promise<void> | void
+  teamMemberAdded: (team: Team, members: string[]) => Promise<void> | void
+  teamMemberRemoved: (team: Team, members: string[]) => Promise<void> | void
   bossBarCreated: (bossBar: BossBar) => Promise<void> | void
   bossBarDeleted: (bossBar: BossBar) => Promise<void> | void
   bossBarUpdated: (bossBar: BossBar) => Promise<void> | void

--- a/lib/plugins/team.js
+++ b/lib/plugins/team.js
@@ -53,7 +53,7 @@ function inject (bot) {
             team.add(player)
             bot.teamMap[player] = team
           })
-          bot.emit('teamMemberAdded', teams[teamName])
+          bot.emit('teamMemberAdded', teams[teamName], packet.players)
         }
         if (mode === 4) {
           packet.players.forEach((player) => {


### PR DESCRIPTION
Added the member list to the teamMemberAdded event too (as it makes some things easier) and properly define the added members list in the BotEvents interface.