### PR TITLE
Fix that the teamRemoved had an undefined team

### DIFF
--- a/lib/plugins/team.js
+++ b/lib/plugins/team.js
@@ -33,7 +33,7 @@ function inject (bot) {
           delete bot.teamMap[member]
         })
         delete teams[teamName]
-        bot.emit('teamRemoved', teams[teamName])
+        bot.emit('teamRemoved', team)
       }
       if (mode === 2) {
         team.update(


### PR DESCRIPTION
Fix that the `teamRemoved` had an undefined team due to the mapping which was already removed getting queried instead of the existing `team` variable being used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an issue where team removal events did not include the correct team data. Events now provide accurate information when a team is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->