### PR TITLE
Include the cape url in the skinData of the player

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -985,11 +985,12 @@ function extractSkinInformation (properties) {
   const skinTexture = JSON.parse(Buffer.from(props.textures.value, 'base64').toString('utf8'))
 
   const skinTextureUrl = skinTexture?.textures?.SKIN?.url ?? undefined
+  const capeTextureUrl = skinTexture?.textures?.CAPE?.url ?? undefined
   const skinTextureModel = skinTexture?.textures?.SKIN?.metadata?.model ?? undefined
 
   if (!skinTextureUrl) {
     return undefined
   }
 
-  return { url: skinTextureUrl, model: skinTextureModel }
+  return { url: skinTextureUrl, capeUrl: capeTextureUrl, model: skinTextureModel }
 }


### PR DESCRIPTION
This adds the url of the cape to the skinData of the player object. Previously only the skin was included and the cape data discarded from the packet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying the player's cape texture alongside the skin texture, when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->