### PR TITLE
feat: apply velocity to entity position

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -1,5 +1,6 @@
 const { Vec3 } = require('vec3')
 const conv = require('../conversions')
+const { performance } = require('perf_hooks')
 // These values are only accurate for versions 1.14 and above (crouch hitbox changes)
 // Todo: hitbox sizes for sleeping, swimming/crawling, and flying with elytra
 const PLAYER_HEIGHT = 1.8
@@ -960,6 +961,24 @@ function inject (bot) {
   function fetchEntity (id) {
     return bot.entities[id] || (bot.entities[id] = new Entity(id))
   }
+
+  let lastTick = performance.now()
+  bot.on('physicsTick', () => {
+    for (const entity of Object.values(bot.entities)) {
+      if (entity.isValid && entity.velocity && !entity.metadata[5] && (entity.name === 'snowball' || entity.name === 'egg' || entity.name === 'ender_pearl')) {
+        const now = performance.now()
+        const delta = (now - lastTick) / 20 // convert to ticks
+        if (entity.velocity.y > -60 / 20 ) {
+          if (entity.velocity.y > -60 / 20) {
+            entity.velocity.y = (entity.velocity.y * (1 - 0.01) ** delta) - (0.03 * ((1 - (1 - 0.01) ** delta) / 0.01))
+          }
+        }
+        entity.position.translate(entity.velocity.x * delta, entity.velocity.y * delta, entity.velocity.z * delta)
+        bot.emit('entityMoved', entity)
+      }
+    }
+    lastTick = performance.now()
+  })
 }
 
 function parseMetadata (metadata, entityMetadata = {}) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const { Vec3 } = require('vec3')
 const { once, sleep, createDoneTask, createTask, withTimeout } = require('../promise_utils')
+const conv = require('../conversions')
 
 module.exports = inject
 
@@ -128,7 +129,10 @@ function inject (bot, { hideErrors }) {
       bot._client.write('use_item', {
         hand: offHand ? 1 : 0,
         sequence,
-        rotation: { x: 0, y: 0 }
+        rotation: {
+          x: conv.toNotchianYaw(bot.entity.yaw),
+          y: conv.toNotchianPitch(bot.entity.pitch)
+        }
       })
     }
   }


### PR DESCRIPTION
This fixes that certain projectiles that are thrown with the hand do not get any movement as the server only send a velocity packet to the client and no high-frequency movement packets like with arrows. Now the position of those entities is calculated client-side from the velocity based on the drag and gravity functions of entities. (See [Minecraft.wiki](https://minecraft.wiki/w/Entity#Motion))

There was also a bug where the view direction of the player wasn't sent to the server in the item use packet which led to the player always looking towards yaw and pitch 0 after clicking with one of those throwable items. (The change in inventory.js)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved movement simulation for snowball, egg, and ender pearl entities, resulting in more accurate in-game behavior.
* **Bug Fixes**
  * Fixed item usage to now correctly use the bot's current orientation, ensuring actions are performed in the direction the bot is facing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->