### PR TITLE
Fix issues with drag and delta calculation with item projectiles

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -964,20 +964,21 @@ function inject (bot) {
 
   let lastTick = performance.now()
   bot.on('physicsTick', () => {
+    const now = performance.now()
+    const delta = (now - lastTick) / 50 // convert to ticks
     for (const entity of Object.values(bot.entities)) {
-      if (entity.isValid && entity.velocity && !entity.metadata[5] && (entity.name === 'snowball' || entity.name === 'egg' || entity.name === 'ender_pearl')) {
-        const now = performance.now()
-        const delta = (now - lastTick) / 20 // convert to ticks
-        if (entity.velocity.y > -60 / 20 ) {
-          if (entity.velocity.y > -60 / 20) {
-            entity.velocity.y = (entity.velocity.y * (1 - 0.01) ** delta) - (0.03 * ((1 - (1 - 0.01) ** delta) / 0.01))
-          }
+      if (entity.isValid && entity.velocity && (entity.name === 'snowball' || entity.name === 'egg' || entity.name === 'ender_pearl')) {
+        entity.velocity.x = entity.velocity.x * (1 - 0.01) ** delta
+        entity.velocity.y = entity.velocity.y * (1 - 0.01) ** delta
+        entity.velocity.z = entity.velocity.z * (1 - 0.01) ** delta
+        if (!entity.metadata[5] && entity.velocity.y > -3) { // check no gravity flag and terminal velocity (60 m/s -> 3m/tick)
+          entity.velocity.y -= 0.03 * ((1 - (1 - 0.01) ** delta) / 0.01)
         }
         entity.position.translate(entity.velocity.x * delta, entity.velocity.y * delta, entity.velocity.z * delta)
         bot.emit('entityMoved', entity)
       }
     }
-    lastTick = performance.now()
+    lastTick = now
   })
 }
 


### PR DESCRIPTION
Sorry that this wasn't in the first PR directly, found another issue with drag. This fixes that the x/z drag was not applied properly and the noGravity flag was applied to the y drag

Also the delta was wrongly calculated (ms -> tick is `/ 50`, not `/ 20`) due to it looking correct ingame without the drag being applied. This now uses the correct delta and also makes it more efficient by only tracking the timestamp once not for all entities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved movement and physics behavior for projectile entities (snowball, egg, ender pearl), resulting in more consistent velocity decay and gravity effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->