### PR TITLE
feat(physics): add boat and horse prediction with minecart riding

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -364,6 +364,8 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   swingArm: (hand: 'left' | 'right' | undefined, showHand?: boolean) => void
 
+  vehicle: Entity | null
+
   mount: (entity: Entity) => void
 
   dismount: () => void

--- a/index.d.ts
+++ b/index.d.ts
@@ -376,6 +376,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
     getCtx: () => import('@nxg-org/mineflayer-physics-util').EPhysicsCtx<import('@nxg-org/mineflayer-physics-util').BoatState> | null
     isDisabled: () => boolean
     getStatus: () => import('@nxg-org/mineflayer-physics-util').BoatStatus | null
+    getPaddleState: () => { leftPaddle: boolean; rightPaddle: boolean } | null
   }
 
   _horsePhysics?: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -370,7 +370,18 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   dismount: () => void
 
-  moveVehicle: (left: number, forward: number) => void
+  moveVehicle: (left: number, forward: number, jump?: boolean) => void
+
+  _boatPhysics?: {
+    getCtx: () => import('@nxg-org/mineflayer-physics-util').EPhysicsCtx<import('@nxg-org/mineflayer-physics-util').BoatState> | null
+    isDisabled: () => boolean
+    getStatus: () => import('@nxg-org/mineflayer-physics-util').BoatStatus | null
+  }
+
+  _horsePhysics?: {
+    getCtx: () => import('@nxg-org/mineflayer-physics-util').EPhysicsCtx<import('@nxg-org/mineflayer-physics-util').HorseState> | null
+    isDisabled: () => boolean
+  }
 
   setQuickBarSlot: (slot: number) => void
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,10 @@ export type ChatLevel = 'enabled' | 'commandsOnly' | 'disabled'
 export type ViewDistance = 'far' | 'normal' | 'short' | 'tiny' | number
 export type MainHands = 'left' | 'right'
 
+export interface EntityMovedMetadata {
+  headRotationOnly?: boolean
+}
+
 export interface PluginOptions {
   [plugin: string]: boolean | Plugin
 }
@@ -109,7 +113,7 @@ export interface BotEvents {
   playerCollect: (collector: Entity, collected: Entity) => Promise<void> | void
   entityAttributes: (entity: Entity) => Promise<void> | void
   entityGone: (entity: Entity) => Promise<void> | void
-  entityMoved: (entity: Entity) => Promise<void> | void
+  entityMoved: (entity: Entity, metadata?: EntityMovedMetadata) => Promise<void> | void
   entityVelocity: (entity: Entity) => Promise<void> | void
   entityDetach: (entity: Entity, vehicle: Entity) => Promise<void> | void
   entityAttach: (entity: Entity, vehicle: Entity) => Promise<void> | void

--- a/lib/physicsCapabilities.js
+++ b/lib/physicsCapabilities.js
@@ -1,0 +1,19 @@
+'use strict'
+
+function hasTransportPhysicsCapability (PhysicsCtor, StateCtor) {
+  return typeof PhysicsCtor === 'function' &&
+    StateCtor != null &&
+    typeof StateCtor.CREATE_FROM_ENTITY === 'function'
+}
+
+function resolveTransportPhysicsCapabilities (physicsUtil) {
+  return {
+    boat: hasTransportPhysicsCapability(physicsUtil.BoatPhysics, physicsUtil.BoatState),
+    horse: hasTransportPhysicsCapability(physicsUtil.HorsePhysics, physicsUtil.HorseState)
+  }
+}
+
+module.exports = {
+  hasTransportPhysicsCapability,
+  resolveTransportPhysicsCapabilities
+}

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -949,30 +949,69 @@ function inject (bot) {
     }
   })
 
-  bot._client.on('set_passengers', ({ entityId, passengers }) => {
-    const passengerEntities = passengers.map((passengerId) => fetchEntity(passengerId))
-    const vehicle = entityId === -1 ? null : bot.entities[entityId]
+  function detachPassengerFromVehicle (passenger, vehicle) {
+    if (!vehicle?.passengers) return
+    const index = vehicle.passengers.indexOf(passenger)
+    if (index !== -1) vehicle.passengers.splice(index, 1)
+    if (passenger.vehicle === vehicle) {
+      passenger.vehicle = null
+    }
+  }
 
-    for (const passengerEntity of passengerEntities) {
-      const originalVehicle = passengerEntity.vehicle
-      if (originalVehicle) {
-        const index = originalVehicle.passengers.indexOf(passengerEntity)
-        originalVehicle.passengers.splice(index, 1)
-      }
-      passengerEntity.vehicle = vehicle
-      if (vehicle) {
-        vehicle.passengers.push(passengerEntity)
+  function handleBotDismount (previousVehicle) {
+    if (bot.vehicle !== previousVehicle) return
+    bot.vehicle = null
+    delete bot.entity.vehicle
+    bot.emit('dismount', previousVehicle)
+  }
+
+  function handleBotMount (vehicle) {
+    if (bot.vehicle === vehicle) return
+    bot.vehicle = vehicle
+    bot.entity.vehicle = vehicle
+    bot.emit('mount')
+  }
+
+  bot._client.on('set_passengers', ({ entityId, passengers }) => {
+    const vehicle = entityId === -1 ? null : fetchEntity(entityId)
+    if (!vehicle) return
+
+    vehicle.passengers ??= []
+    const newPassengerIds = new Set(passengers)
+
+    for (const passenger of [...vehicle.passengers]) {
+      if (!newPassengerIds.has(passenger.id)) {
+        detachPassengerFromVehicle(passenger, vehicle)
+        if (passenger.id === bot.entity.id) {
+          handleBotDismount(vehicle)
+        }
       }
     }
 
-    if (passengers.includes(bot.entity.id)) {
-      const originalVehicle = bot.vehicle
-      if (entityId === -1) {
-        bot.vehicle = null
-        bot.emit('dismount', originalVehicle)
-      } else {
-        bot.vehicle = bot.entities[entityId]
-        bot.emit('mount')
+    // The packet is authoritative even if our local passenger list was already
+    // incomplete or stale. Do not leave the bot mounted merely because it was
+    // missing from vehicle.passengers before this update arrived.
+    if (bot.vehicle === vehicle && !newPassengerIds.has(bot.entity.id)) {
+      handleBotDismount(vehicle)
+    }
+
+    for (const passengerId of passengers) {
+      const passenger = fetchEntity(passengerId)
+      const alreadyAttached = passenger.vehicle === vehicle && vehicle.passengers.includes(passenger)
+
+      if (!alreadyAttached) {
+        if (passenger.vehicle && passenger.vehicle !== vehicle) {
+          detachPassengerFromVehicle(passenger, passenger.vehicle)
+        }
+
+        passenger.vehicle = vehicle
+        if (!vehicle.passengers.includes(passenger)) {
+          vehicle.passengers.push(passenger)
+        }
+      }
+
+      if (passengerId === bot.entity.id) {
+        handleBotMount(vehicle)
       }
     }
   })
@@ -1051,6 +1090,40 @@ function inject (bot) {
     useEntity(target, 0)
   }
 
+  const DISMOUNT_REQUEST_TIMEOUT_MS = 3000
+  let dismountRequested = false
+  let dismountRequestedAt = 0
+
+  function clearDismountRequest () {
+    dismountRequested = false
+    dismountRequestedAt = 0
+  }
+
+  function requestDismount () {
+    dismountRequested = true
+    dismountRequestedAt = performance.now()
+  }
+
+  function isDismountRequestActive () {
+    if (!dismountRequested) return false
+    if (performance.now() - dismountRequestedAt > DISMOUNT_REQUEST_TIMEOUT_MS) {
+      clearDismountRequest()
+      return false
+    }
+    return true
+  }
+
+  function steerVehicleJumpMask (jump) {
+    let mask = jump ? 0x01 : 0x00
+    if (isDismountRequestActive()) {
+      mask |= 0x02
+    }
+    return mask
+  }
+
+  bot.on('dismount', clearDismountRequest)
+  bot.on('mount', clearDismountRequest)
+
   function moveVehicle (left, forward, jump = false) {
     if (bot.supportFeature('newPlayerInputPacket')) {
       // docs:
@@ -1068,13 +1141,14 @@ function inject (bot) {
       bot._client.write('steer_vehicle', {
         sideways: left,
         forward,
-        jump: jump ? 0x01 : 0x02
+        jump: steerVehicleJumpMask(jump)
       })
     }
   }
 
   function dismount () {
     if (bot.vehicle) {
+      requestDismount()
       if (bot.supportFeature('newPlayerInputPacket')) {
         bot._client.write('player_input', {
           inputs: {
@@ -1085,7 +1159,7 @@ function inject (bot) {
         bot._client.write('steer_vehicle', {
           sideways: 0.0,
           forward: 0.0,
-          jump: 0x02
+          jump: steerVehicleJumpMask(false)
         })
       }
     } else {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -424,6 +424,7 @@ function inject (bot) {
   bot._client.on('entity_velocity', (packet) => {
     // entity velocity
     const entity = fetchEntity(packet.entityId)
+    if (isControlledBoat(entity)) return
     let notchVel
     // bot.supportFeature('entityVelocityIsLpVec3') is broken for version 1.8.8
     if (packet.velocity != null) {
@@ -452,6 +453,7 @@ function inject (bot) {
   bot._client.on('rel_entity_move', (packet) => {
     // entity relative move
     const entity = fetchEntity(packet.entityId)
+    if (isControlledBoat(entity)) return
     updateEntityRelativeMove(entity, packet)
     bot.emit('entityVelocity', entity)
     emitBoatVehicleCorrection(entity, { kind: 'rel_entity_move', replaceVelocity: false })
@@ -461,6 +463,7 @@ function inject (bot) {
   bot._client.on('entity_look', (packet) => {
     // entity look
     const entity = fetchEntity(packet.entityId)
+    if (isControlledBoat(entity)) return
     if (packet.yaw && packet.pitch) {
       entity.yaw = conv.fromNotchianYawByte(packet.yaw)
       entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
@@ -471,6 +474,7 @@ function inject (bot) {
   bot._client.on('entity_move_look', (packet) => {
     // entity look and relative move
     const entity = fetchEntity(packet.entityId)
+    if (isControlledBoat(entity)) return
     updateEntityRelativeMove(entity, packet)
     if (packet.yaw != null && packet.pitch != null) {
       entity.yaw = conv.fromNotchianYawByte(packet.yaw)
@@ -484,6 +488,7 @@ function inject (bot) {
   bot._client.on('entity_teleport', (packet) => {
     // entity teleport
     const entity = fetchEntity(packet.entityId)
+    if (isControlledBoat(entity)) return
     if (bot.supportFeature('fixedPointPosition')) {
       entity.position.set(packet.x / 32, packet.y / 32, packet.z / 32)
     }
@@ -500,12 +505,10 @@ function inject (bot) {
     const vehicle = bot.vehicle
     if (!vehicle) return
 
-    vehicle.position.set(packet.x, packet.y, packet.z)
-    vehicle.yaw = conv.fromNotchianYaw(packet.yaw)
-    vehicle.pitch = conv.fromNotchianPitch(packet.pitch)
-
-    if (bot.version === '1.17.1' && vehicle.name === 'boat') {
-      bot.emit('vehicleCorrection', vehicle, { kind: 'vehicle_move', replaceVelocity: false })
+    if (bot.version === '1.17.1' && vehicle.name === 'boat' && isControlledBoat(vehicle)) {
+      vehicle.position.set(packet.x, packet.y, packet.z)
+      vehicle.yaw = conv.fromNotchianYaw(packet.yaw)
+      vehicle.pitch = conv.fromNotchianPitch(packet.pitch)
       bot._client.write('vehicle_move', {
         x: packet.x,
         y: packet.y,
@@ -513,8 +516,14 @@ function inject (bot) {
         yaw: packet.yaw,
         pitch: packet.pitch
       })
+      bot.emit('vehicleCorrection', vehicle, { kind: 'vehicle_move', replaceVelocity: false })
       bot.emit('entityMoved', vehicle)
+      return
     }
+
+    vehicle.position.set(packet.x, packet.y, packet.z)
+    vehicle.yaw = conv.fromNotchianYaw(packet.yaw)
+    vehicle.pitch = conv.fromNotchianPitch(packet.pitch)
   })
 
   // 1.21.3 - merges the packets above
@@ -997,8 +1006,16 @@ function inject (bot) {
     bot.emit('mount')
   }
 
+  function isControlledBoat (entity) {
+    return bot.version === '1.17.1' &&
+      bot.vehicle === entity &&
+      entity.name === 'boat' &&
+      entity.passengers?.[0]?.id === bot.entity.id
+  }
+
   function emitBoatVehicleCorrection (entity, correction) {
     if (bot.version !== '1.17.1' || bot.vehicle !== entity || entity.name !== 'boat') return
+    if (!isControlledBoat(entity)) return
     bot.emit('vehicleCorrection', entity, correction)
   }
 

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -433,7 +433,6 @@ function inject (bot) {
       notchVel = new Vec3(packet.velocityX, packet.velocityY, packet.velocityZ)
     }
     updateEntityVelocity(entity, conv.fromNotchVelocity(notchVel))
-    emitBoatVehicleCorrection(entity, { kind: 'entity_velocity', replaceVelocity: true })
   })
 
   bot._client.on('entity_destroy', (packet) => {
@@ -456,7 +455,6 @@ function inject (bot) {
     if (isControlledBoat(entity)) return
     updateEntityRelativeMove(entity, packet)
     bot.emit('entityVelocity', entity)
-    emitBoatVehicleCorrection(entity, { kind: 'rel_entity_move', replaceVelocity: false })
     bot.emit('entityMoved', entity)
   })
 
@@ -481,7 +479,6 @@ function inject (bot) {
       entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
     }
     bot.emit('entityVelocity', entity)
-    emitBoatVehicleCorrection(entity, { kind: 'entity_move_look', replaceVelocity: false })
     bot.emit('entityMoved', entity)
   })
 
@@ -497,7 +494,6 @@ function inject (bot) {
     }
     entity.yaw = conv.fromNotchianYawByte(packet.yaw)
     entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
-    emitBoatVehicleCorrection(entity, { kind: 'entity_teleport', replaceVelocity: false })
     bot.emit('entityMoved', entity)
   })
 
@@ -1014,12 +1010,6 @@ function inject (bot) {
       bot.vehicle === entity &&
       entity.name === 'boat' &&
       entity.passengers?.[0]?.id === bot.entity.id
-  }
-
-  function emitBoatVehicleCorrection (entity, correction) {
-    if (bot.version !== '1.17.1' || bot.vehicle !== entity || entity.name !== 'boat') return
-    if (!isControlledBoat(entity)) return
-    bot.emit('vehicleCorrection', entity, correction)
   }
 
   function resolvePassengerEntity (passengerId) {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -464,7 +464,7 @@ function inject (bot) {
     // entity look
     const entity = fetchEntity(packet.entityId)
     if (isControlledBoat(entity)) return
-    if (packet.yaw && packet.pitch) {
+    if (packet.yaw != null && packet.pitch != null) {
       entity.yaw = conv.fromNotchianYawByte(packet.yaw)
       entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
     }
@@ -524,6 +524,7 @@ function inject (bot) {
     vehicle.position.set(packet.x, packet.y, packet.z)
     vehicle.yaw = conv.fromNotchianYaw(packet.yaw)
     vehicle.pitch = conv.fromNotchianPitch(packet.pitch)
+    bot.emit('entityMoved', vehicle)
   })
 
   // 1.21.3 - merges the packets above

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -217,19 +217,18 @@ function inject (bot) {
     if (emitEvent) bot.emit('entityVelocity', entity)
   }
 
-  function updateEntityRelativeMove (entity, packet) {  
+  function updateEntityRelativeMove (entity, packet) {
     if (bot.supportFeature('fixedPointDelta')) {
       const dx = packet.dX / 32
       const dy = packet.dY / 32
       const dz = packet.dZ / 32
       entity.position.translate(dx, dy, dz)
       updateEntityVelocity(entity, new Vec3(dx, dy, dz), false)
-    } 
+    } else if (bot.supportFeature('fixedPointDelta128')) {
     // this has entity velocity handled elsewhere.
-    else if (bot.supportFeature('fixedPointDelta128'))  {
-      const dx = packet.dX /  (128 * 32)
-      const dy = packet.dY /  (128 * 32)
-      const dz = packet.dZ /  (128 * 32)
+      const dx = packet.dX / (128 * 32)
+      const dy = packet.dY / (128 * 32)
+      const dz = packet.dZ / (128 * 32)
       entity.position.translate(dx, dy, dz)
     }
   }
@@ -433,6 +432,9 @@ function inject (bot) {
       notchVel = new Vec3(packet.velocityX, packet.velocityY, packet.velocityZ)
     }
     updateEntityVelocity(entity, conv.fromNotchVelocity(notchVel))
+    if (isControlledHorse(entity)) {
+      bot.emit('vehicleCorrection', entity, { kind: 'entity_velocity', replaceVelocity: true })
+    }
   })
 
   bot._client.on('entity_destroy', (packet) => {
@@ -452,7 +454,7 @@ function inject (bot) {
   bot._client.on('rel_entity_move', (packet) => {
     // entity relative move
     const entity = fetchEntity(packet.entityId)
-    if (isControlledBoat(entity)) return
+    if (isLocallyControlledVehicle(entity)) return
     updateEntityRelativeMove(entity, packet)
     bot.emit('entityVelocity', entity)
     bot.emit('entityMoved', entity)
@@ -461,7 +463,7 @@ function inject (bot) {
   bot._client.on('entity_look', (packet) => {
     // entity look
     const entity = fetchEntity(packet.entityId)
-    if (isControlledBoat(entity)) return
+    if (isLocallyControlledVehicle(entity)) return
     if (packet.yaw != null && packet.pitch != null) {
       entity.yaw = conv.fromNotchianYawByte(packet.yaw)
       entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
@@ -472,7 +474,7 @@ function inject (bot) {
   bot._client.on('entity_move_look', (packet) => {
     // entity look and relative move
     const entity = fetchEntity(packet.entityId)
-    if (isControlledBoat(entity)) return
+    if (isLocallyControlledVehicle(entity)) return
     updateEntityRelativeMove(entity, packet)
     if (packet.yaw != null && packet.pitch != null) {
       entity.yaw = conv.fromNotchianYawByte(packet.yaw)
@@ -485,7 +487,7 @@ function inject (bot) {
   bot._client.on('entity_teleport', (packet) => {
     // entity teleport
     const entity = fetchEntity(packet.entityId)
-    if (isControlledBoat(entity)) return
+    if (isLocallyControlledVehicle(entity)) return
     if (bot.supportFeature('fixedPointPosition')) {
       entity.position.set(packet.x / 32, packet.y / 32, packet.z / 32)
     }
@@ -502,6 +504,22 @@ function inject (bot) {
     if (!vehicle) return
 
     if (bot.version === '1.17.1' && vehicle.name === 'boat' && isControlledBoat(vehicle)) {
+      vehicle.position.set(packet.x, packet.y, packet.z)
+      vehicle.yaw = conv.fromNotchianYaw(packet.yaw)
+      vehicle.pitch = conv.fromNotchianPitch(packet.pitch)
+      bot._client.write('vehicle_move', {
+        x: packet.x,
+        y: packet.y,
+        z: packet.z,
+        yaw: packet.yaw,
+        pitch: packet.pitch
+      })
+      bot.emit('vehicleCorrection', vehicle, { kind: 'vehicle_move', replaceVelocity: false })
+      bot.emit('entityMoved', vehicle)
+      return
+    }
+
+    if (bot.version === '1.17.1' && isControlledHorse(vehicle)) {
       vehicle.position.set(packet.x, packet.y, packet.z)
       vehicle.yaw = conv.fromNotchianYaw(packet.yaw)
       vehicle.pitch = conv.fromNotchianPitch(packet.pitch)
@@ -1012,6 +1030,19 @@ function inject (bot) {
       entity.passengers?.[0]?.id === bot.entity.id
   }
 
+  function isControlledHorse (entity) {
+    return bot.version === '1.17.1' &&
+      bot.vehicle === entity &&
+      ['horse', 'donkey', 'mule', 'skeleton_horse', 'zombie_horse'].includes(entity.name) &&
+      entity.passengers?.[0]?.id === bot.entity.id &&
+      typeof entity.metadata?.[17] === 'number' &&
+      (entity.metadata[17] & 0x04) !== 0
+  }
+
+  function isLocallyControlledVehicle (entity) {
+    return isControlledBoat(entity) || isControlledHorse(entity)
+  }
+
   function resolvePassengerEntity (passengerId) {
     if (passengerId === bot.entity.id) return bot.entity
     return fetchEntity(passengerId)
@@ -1072,8 +1103,7 @@ function inject (bot) {
   // dismounting when the vehicle is gone
   bot.on('entityGone', (entity) => {
     if (bot.vehicle === entity) {
-      bot.vehicle = null
-      bot.emit('dismount', (entity))
+      handleBotDismount(entity)
     }
     if (entity.passengers) {
       for (const passenger of entity.passengers) {
@@ -1249,7 +1279,7 @@ function inject (bot) {
     const now = performance.now()
     const delta = (now - lastTick) / 50 // convert to ticks
     for (const entity of Object.values(bot.entities)) {
-      if (entity.isValid && entity.velocity && (entity.name === "falling_block" || entity.name === 'snowball' || entity.name === 'egg' || entity.name === 'ender_pearl')) {
+      if (entity.isValid && entity.velocity && (entity.name === 'falling_block' || entity.name === 'snowball' || entity.name === 'egg' || entity.name === 'ender_pearl')) {
         entity.velocity.x = entity.velocity.x * (1 - 0.01) ** delta
         entity.velocity.y = entity.velocity.y * (1 - 0.01) ** delta
         entity.velocity.z = entity.velocity.z * (1 - 0.01) ** delta

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -1002,6 +1002,11 @@ function inject (bot) {
     bot.emit('vehicleCorrection', entity, correction)
   }
 
+  function resolvePassengerEntity (passengerId) {
+    if (passengerId === bot.entity.id) return bot.entity
+    return fetchEntity(passengerId)
+  }
+
   bot._client.on('set_passengers', ({ entityId, passengers }) => {
     const vehicle = entityId === -1 ? null : fetchEntity(entityId)
     if (!vehicle) return
@@ -1026,7 +1031,7 @@ function inject (bot) {
     }
 
     for (const passengerId of passengers) {
-      const passenger = fetchEntity(passengerId)
+      const passenger = resolvePassengerEntity(passengerId)
       const alreadyAttached = passenger.vehicle === vehicle && vehicle.passengers.includes(passenger)
 
       if (!alreadyAttached) {
@@ -1045,7 +1050,7 @@ function inject (bot) {
       }
     }
 
-    vehicle.passengers = passengers.map((passengerId) => fetchEntity(passengerId))
+    vehicle.passengers = passengers.map((passengerId) => resolvePassengerEntity(passengerId))
   })
 
   // dismounting when the vehicle is gone

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -210,6 +210,11 @@ function inject (bot) {
     }
     entity.yaw = conv.fromNotchianYawByte(pos.yaw)
     entity.pitch = conv.fromNotchianPitchByte(pos.pitch)
+    if (typeof pos.headPitch === 'number' && Number.isFinite(pos.headPitch)) {
+      // The field is called headPitch in the protocol schema, but stores the
+      // horizontal head rotation for living entities in unified spawn packets.
+      entity.headYaw = conv.fromNotchianYawByte(pos.headPitch)
+    }
   }
 
   function updateEntityVelocity (entity, velocity, emitEvent = true) {
@@ -406,7 +411,9 @@ function inject (bot) {
 
     entity.yaw = conv.fromNotchianYawByte(packet.yaw)
     entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
-    entity.headPitch = conv.fromNotchianPitchByte(packet.headPitch)
+    // In 1.17.1 this field is named headPitch by minecraft-data, but the
+    // protocol value is the living entity's horizontal head rotation.
+    entity.headYaw = conv.fromNotchianYawByte(packet.headPitch)
 
     let notchVel
     if (packet.velocity != null) {
@@ -554,8 +561,9 @@ function inject (bot) {
   bot._client.on('entity_head_rotation', (packet) => {
     // entity head look
     const entity = fetchEntity(packet.entityId)
+    if (isLocallyControlledVehicle(entity)) return
     entity.headYaw = conv.fromNotchianYawByte(packet.headYaw)
-    bot.emit('entityMoved', entity)
+    bot.emit('entityMoved', entity, { headRotationOnly: true })
   })
 
   bot._client.on('entity_status', (packet) => {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -984,12 +984,14 @@ function inject (bot) {
   })
 
   function detachPassengerFromVehicle (passenger, vehicle) {
-    if (!vehicle?.passengers) return
-    const index = vehicle.passengers.indexOf(passenger)
+    if (!vehicle) return false
+    const index = vehicle.passengers?.indexOf(passenger) ?? -1
+    const wasAttached = index !== -1 || passenger.vehicle === vehicle
     if (index !== -1) vehicle.passengers.splice(index, 1)
     if (passenger.vehicle === vehicle) {
       passenger.vehicle = null
     }
+    return wasAttached
   }
 
   function handleBotDismount (previousVehicle) {
@@ -1033,7 +1035,9 @@ function inject (bot) {
 
     for (const passenger of [...vehicle.passengers]) {
       if (!newPassengerIds.has(passenger.id)) {
-        detachPassengerFromVehicle(passenger, vehicle)
+        if (detachPassengerFromVehicle(passenger, vehicle)) {
+          bot.emit('entityDetach', passenger, vehicle)
+        }
         if (passenger.id === bot.entity.id) {
           handleBotDismount(vehicle)
         }
@@ -1053,13 +1057,17 @@ function inject (bot) {
 
       if (!alreadyAttached) {
         if (passenger.vehicle && passenger.vehicle !== vehicle) {
-          detachPassengerFromVehicle(passenger, passenger.vehicle)
+          const previousVehicle = passenger.vehicle
+          if (detachPassengerFromVehicle(passenger, previousVehicle)) {
+            bot.emit('entityDetach', passenger, previousVehicle)
+          }
         }
 
         passenger.vehicle = vehicle
         if (!vehicle.passengers.includes(passenger)) {
           vehicle.passengers.push(passenger)
         }
+        bot.emit('entityAttach', passenger, vehicle)
       }
 
       if (passengerId === bot.entity.id) {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -432,6 +432,7 @@ function inject (bot) {
       notchVel = new Vec3(packet.velocityX, packet.velocityY, packet.velocityZ)
     }
     updateEntityVelocity(entity, conv.fromNotchVelocity(notchVel))
+    emitBoatVehicleCorrection(entity, { kind: 'entity_velocity', replaceVelocity: true })
   })
 
   bot._client.on('entity_destroy', (packet) => {
@@ -453,6 +454,7 @@ function inject (bot) {
     const entity = fetchEntity(packet.entityId)
     updateEntityRelativeMove(entity, packet)
     bot.emit('entityVelocity', entity)
+    emitBoatVehicleCorrection(entity, { kind: 'rel_entity_move', replaceVelocity: false })
     bot.emit('entityMoved', entity)
   })
 
@@ -475,6 +477,7 @@ function inject (bot) {
       entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
     }
     bot.emit('entityVelocity', entity)
+    emitBoatVehicleCorrection(entity, { kind: 'entity_move_look', replaceVelocity: false })
     bot.emit('entityMoved', entity)
   })
 
@@ -489,7 +492,29 @@ function inject (bot) {
     }
     entity.yaw = conv.fromNotchianYawByte(packet.yaw)
     entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
+    emitBoatVehicleCorrection(entity, { kind: 'entity_teleport', replaceVelocity: false })
     bot.emit('entityMoved', entity)
+  })
+
+  bot._client.on('vehicle_move', (packet) => {
+    const vehicle = bot.vehicle
+    if (!vehicle) return
+
+    vehicle.position.set(packet.x, packet.y, packet.z)
+    vehicle.yaw = conv.fromNotchianYaw(packet.yaw)
+    vehicle.pitch = conv.fromNotchianPitch(packet.pitch)
+
+    if (bot.version === '1.17.1' && vehicle.name === 'boat') {
+      bot.emit('vehicleCorrection', vehicle, { kind: 'vehicle_move', replaceVelocity: false })
+      bot._client.write('vehicle_move', {
+        x: packet.x,
+        y: packet.y,
+        z: packet.z,
+        yaw: packet.yaw,
+        pitch: packet.pitch
+      })
+      bot.emit('entityMoved', vehicle)
+    }
   })
 
   // 1.21.3 - merges the packets above
@@ -972,6 +997,11 @@ function inject (bot) {
     bot.emit('mount')
   }
 
+  function emitBoatVehicleCorrection (entity, correction) {
+    if (bot.version !== '1.17.1' || bot.vehicle !== entity || entity.name !== 'boat') return
+    bot.emit('vehicleCorrection', entity, correction)
+  }
+
   bot._client.on('set_passengers', ({ entityId, passengers }) => {
     const vehicle = entityId === -1 ? null : fetchEntity(entityId)
     if (!vehicle) return
@@ -1014,6 +1044,8 @@ function inject (bot) {
         handleBotMount(vehicle)
       }
     }
+
+    vehicle.passengers = passengers.map((passengerId) => fetchEntity(passengerId))
   })
 
   // dismounting when the vehicle is gone

--- a/lib/plugins/entity_physics.js
+++ b/lib/plugins/entity_physics.js
@@ -67,21 +67,12 @@ function inject (bot) {
   }
 
   function canSimulateEntity (entity) {
-    if (!entity || entity === bot.entity || entity.isValid === false) return false
+    if (!entity || entity === bot.entity || entity === bot.vehicle || entity.isValid === false) return false
     if (!entity.position || !entity.velocity) return false
     if (typeof entity.height !== 'number' || typeof entity.width !== 'number') return false
     if (entity.type === 'player') return false
-    if (bot.version === '1.17.1') {
-      if (isRideableHorseEntityName(entity.name)) {
-        return false
-      }
-      if (
-        bot.vehicle === entity &&
-        entity.passengers?.[0]?.id === bot.entity.id &&
-        entity.name === 'boat'
-      ) {
-        return false
-      }
+    if (bot.version === '1.17.1' && isRideableHorseEntityName(entity.name)) {
+      return false
     }
     return resolveEntityType(entity) != null
   }
@@ -109,7 +100,10 @@ function inject (bot) {
   }
 
   function simulateEntity (entity) {
-    if (!canSimulateEntity(entity)) return null
+    if (!canSimulateEntity(entity)) {
+      if (entity?.id != null) contexts.delete(entity.id)
+      return null
+    }
 
     const ctx = contexts.get(entity.id)
     if (ctx == null) return null

--- a/lib/plugins/entity_physics.js
+++ b/lib/plugins/entity_physics.js
@@ -5,7 +5,20 @@ const {
   PhysicsWorldSettings
 } = require('@nxg-org/mineflayer-physics-util')
 
+const RIDEABLE_HORSE_ENTITY_NAMES = new Set([
+  'horse',
+  'donkey',
+  'mule',
+  'skeleton_horse',
+  'zombie_horse'
+])
+
+function isRideableHorseEntityName (name) {
+  return name != null && RIDEABLE_HORSE_ENTITY_NAMES.has(name)
+}
+
 module.exports = inject
+module.exports.isRideableHorseEntityName = isRideableHorseEntityName
 
 function inject (bot) {
   const physics = new EntityPhysics(bot.registry)
@@ -58,20 +71,17 @@ function inject (bot) {
     if (!entity.position || !entity.velocity) return false
     if (typeof entity.height !== 'number' || typeof entity.width !== 'number') return false
     if (entity.type === 'player') return false
-    if (
-      bot.version === '1.17.1' &&
-      bot.vehicle === entity &&
-      entity.passengers?.[0]?.id === bot.entity.id &&
-      (
-        entity.name === 'boat' ||
-        entity.name === 'horse' ||
-        entity.name === 'donkey' ||
-        entity.name === 'mule' ||
-        entity.name === 'skeleton_horse' ||
-        entity.name === 'zombie_horse'
-      )
-    ) {
-      return false
+    if (bot.version === '1.17.1') {
+      if (isRideableHorseEntityName(entity.name)) {
+        return false
+      }
+      if (
+        bot.vehicle === entity &&
+        entity.passengers?.[0]?.id === bot.entity.id &&
+        entity.name === 'boat'
+      ) {
+        return false
+      }
     }
     return resolveEntityType(entity) != null
   }

--- a/lib/plugins/entity_physics.js
+++ b/lib/plugins/entity_physics.js
@@ -58,6 +58,21 @@ function inject (bot) {
     if (!entity.position || !entity.velocity) return false
     if (typeof entity.height !== 'number' || typeof entity.width !== 'number') return false
     if (entity.type === 'player') return false
+    if (
+      bot.version === '1.17.1' &&
+      bot.vehicle === entity &&
+      entity.passengers?.[0]?.id === bot.entity.id &&
+      (
+        entity.name === 'boat' ||
+        entity.name === 'horse' ||
+        entity.name === 'donkey' ||
+        entity.name === 'mule' ||
+        entity.name === 'skeleton_horse' ||
+        entity.name === 'zombie_horse'
+      )
+    ) {
+      return false
+    }
     return resolveEntityType(entity) != null
   }
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -13,6 +13,8 @@ const {
   applyToPlayerState,
   BoatPhysics,
   BoatState,
+  HorsePhysics,
+  HorseState,
   ControlStateHandler
 } = require('@nxg-org/mineflayer-physics-util')
 const { JavaFloat } = require('../javamath')
@@ -31,8 +33,11 @@ const MIN_DELTA_DIST_SQUARED = 4.0E-8
 const BOAT_DISMOUNT_YAW_OFFSETS = [0, Math.PI / 8, -Math.PI / 8, Math.PI / 4, -Math.PI / 4]
 const MAX_BOAT_DISMOUNT_DISTANCE = 2.5
 const BOAT_PHYSICS_VERSION = '1.17.1'
+const HORSE_PHYSICS_VERSION = '1.17.1'
 const BOAT_CORRECTION_LIMIT = 3
 const BOAT_CORRECTION_WINDOW_MS = 1000
+const HORSE_CORRECTION_LIMIT = 3
+const HORSE_CORRECTION_WINDOW_MS = 1000
 const MAX_BOAT_PASSENGER_YAW_OFFSET = 105 * Math.PI / 180
 const BOAT_PHYS_DEBUG = !!process.env.BOAT_PHYS_DEBUG
 const MAX_VEHICLE_MOVE_COMPONENT = 0.9800000190734863
@@ -45,9 +50,26 @@ const RIDEABLE_MINECART_ENTITY_NAMES = new Set([
   'spawner_minecart',
   'command_block_minecart'
 ])
+const RIDEABLE_HORSE_ENTITY_NAMES = new Set([
+  'horse',
+  'donkey',
+  'mule',
+  'skeleton_horse',
+  'zombie_horse'
+])
+const HORSE_DISMOUNT_YAW_OFFSETS = [Math.PI / 2, -Math.PI / 2, 0, Math.PI / 8, -Math.PI / 8]
 
 function isRideableMinecartEntity (entity) {
   return entity != null && RIDEABLE_MINECART_ENTITY_NAMES.has(entity.name)
+}
+
+function isRideableHorseEntity (entity) {
+  return entity != null && RIDEABLE_HORSE_ENTITY_NAMES.has(entity.name)
+}
+
+function horseSaddleFlag (entity) {
+  const flags = entity?.metadata?.[17]
+  return typeof flags === 'number' && (flags & 0x04) !== 0
 }
 
 function isServerAuthoritativeMinecart (vehicle) {
@@ -124,6 +146,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   const physics = new BotcraftPhysics(bot.registry)
   const boatPhysics = new BoatPhysics(bot.registry)
+  const horsePhysics = new HorsePhysics(bot.registry)
   initSetup(bot.registry)
 
   const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')
@@ -175,6 +198,21 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   let boatTickPacketsReady = false
   /** @type {Record<string, number>} */
   const boatDebugCorrectionCounts = {}
+
+  /**
+   * @type {import('@nxg-org/mineflayer-physics-util').EPhysicsCtx<import('@nxg-org/mineflayer-physics-util').HorseState> | null}
+   */
+  let horseCtx = null
+  let horseVehicleId = null
+  let horsePhysicsDisabled = false
+  let horsePhysicsDisabledLogged = false
+  /** @type {{ kind: string, replaceVelocity: boolean } | null} */
+  let pendingHorseCorrection = null
+  let horseCorrectionCount = 0
+  let horseCorrectionWindowStart = 0
+  let horseTickPacketsReady = false
+  /** @type {{ released: boolean, jumpBoost: number } | null} */
+  let pendingHorseJumpRelease = null
 
   let lastSent = {
     x: 0,
@@ -355,6 +393,36 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
   }
 
+  function getHorsePassengerFeetOffsetY (horse) {
+    const height = horse.height ?? 1.6
+    let variantOffset = 0
+    if (horse.name === 'donkey' || horse.name === 'mule') {
+      variantOffset = 0.25
+    } else if (horse.name === 'skeleton_horse') {
+      variantOffset = 0.1875
+    }
+    return height * 0.75 - variantOffset - 0.35
+  }
+
+  function syncEntityWithHorse () {
+    const vehicle = bot.vehicle
+    if (!vehicle) return
+
+    bot.entity.position.set(
+      vehicle.position.x,
+      vehicle.position.y + getHorsePassengerFeetOffsetY(vehicle),
+      vehicle.position.z
+    )
+
+    const vehicleVelocity = vehicle.velocity
+    bot.entity.velocity.set(
+      vehicleVelocity?.x ?? 0,
+      vehicleVelocity?.y ?? 0,
+      vehicleVelocity?.z ?? 0
+    )
+    bot.entity.onGround = vehicle.onGround ?? false
+  }
+
   function syncEntityWithVehicle () {
     const vehicle = bot.vehicle
     if (!vehicle) return
@@ -428,6 +496,170 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       bot.entity.onGround = false
       return
     }
+  }
+
+  function isHorsePhysicsVersion () {
+    return bot.version === HORSE_PHYSICS_VERSION
+  }
+
+  function isHorseController () {
+    const vehicle = bot.vehicle
+    return isHorsePhysicsVersion() &&
+      vehicle &&
+      isRideableHorseEntity(vehicle) &&
+      vehicle.passengers?.[0]?.id === bot.entity.id &&
+      horseSaddleFlag(vehicle)
+  }
+
+  function destroyHorseContext () {
+    horseCtx = null
+    horseVehicleId = null
+    pendingHorseCorrection = null
+    pendingHorseJumpRelease = null
+    horseTickPacketsReady = false
+  }
+
+  function resetHorseCorrectionTracking () {
+    horseCorrectionCount = 0
+    horseCorrectionWindowStart = 0
+    horsePhysicsDisabled = false
+    horsePhysicsDisabledLogged = false
+  }
+
+  function createHorseContext (vehicle) {
+    ensureVehicleRotationDefaults(vehicle)
+    const entityType = bot.registry.entitiesByName[vehicle.name] ?? bot.registry.entitiesByName.horse
+    const state = HorseState.CREATE_FROM_ENTITY(horsePhysics, vehicle, ControlStateHandler.COPY_BOT(bot))
+    horseCtx = EPhysicsCtx.FROM_ENTITY_STATE(horsePhysics, state, entityType)
+    horseVehicleId = vehicle.id
+    resetHorseCorrectionTracking()
+    pendingHorseCorrection = null
+    pendingHorseJumpRelease = null
+    horseTickPacketsReady = false
+  }
+
+  function ensureHorseContext () {
+    const vehicle = bot.vehicle
+    if (!vehicle || !isRideableHorseEntity(vehicle) || !horseSaddleFlag(vehicle)) {
+      destroyHorseContext()
+      return false
+    }
+    if (!horseCtx || horseVehicleId !== vehicle.id) {
+      createHorseContext(vehicle)
+    }
+    return true
+  }
+
+  function disableHorsePhysicsWithLog (reason) {
+    if (horsePhysicsDisabled) return
+    horsePhysicsDisabled = true
+    if (!horsePhysicsDisabledLogged) {
+      console.warn(`[mineflayer] disabled local horse physics: ${reason}`)
+      horsePhysicsDisabledLogged = true
+    }
+  }
+
+  function applyPendingHorseCorrection () {
+    if (!pendingHorseCorrection || !horseCtx || !bot.vehicle) return false
+    const correction = pendingHorseCorrection
+    pendingHorseCorrection = null
+
+    if (correction.kind === 'entity_velocity') {
+      horseCtx.state.vel.set(
+        bot.vehicle.velocity.x,
+        bot.vehicle.velocity.y,
+        bot.vehicle.velocity.z
+      )
+      return true
+    }
+
+    if (correction.kind !== 'vehicle_move') {
+      return false
+    }
+
+    horseCtx.state.rebaseFromEntity(bot.vehicle, {
+      replaceVelocity: correction.replaceVelocity === true
+    })
+    return true
+  }
+
+  function syncControlsToHorseState () {
+    if (!horseCtx) return
+    horseCtx.state.updateControls(
+      ControlStateHandler.COPY_BOT(bot),
+      bot.entity.yaw,
+      bot.entity.pitch
+    )
+    horseCtx.state.updateFromHorseEntity(bot.vehicle)
+    pendingHorseJumpRelease = horseCtx.state.updateJumpCharge(controlState.jump)
+  }
+
+  function isValidHorseDismountPosition (x, y, z, horse) {
+    if (!isOutsideHorizontalEntityAabb(x, z, horse)) return false
+    const halfWidth = (bot.entity.width ?? 0.6) / 2
+    for (const dy of [0, 1]) {
+      for (const dx of [-halfWidth, 0, halfWidth]) {
+        for (const dz of [-halfWidth, 0, halfWidth]) {
+          if (isSolidBlockAt(new Vec3(x + dx, y + dy, z + dz))) return false
+        }
+      }
+    }
+    if (isSolidBlockAt(new Vec3(x, y - 0.01, z))) return true
+    return isSolidBlockAt(new Vec3(x, y - 1, z))
+  }
+
+  function offsetPlayerFromHorse (horse) {
+    const playerWidth = bot.entity.width ?? 0.6
+    const horseWidth = horse.width ?? 1.3964844
+    const distance = (horseWidth + playerWidth) / 2 + 0.2
+    const feetY = horse.position.y + getHorsePassengerFeetOffsetY(horse)
+
+    for (const yawOffset of HORSE_DISMOUNT_YAW_OFFSETS) {
+      const dirYaw = horse.yaw + yawOffset
+      const x = horse.position.x - Math.sin(dirYaw) * distance
+      const z = horse.position.z + Math.cos(dirYaw) * distance
+      if (!isValidHorseDismountPosition(x, feetY, z, horse)) continue
+      bot.entity.position.set(x, feetY, z)
+      bot.entity.velocity.set(0, 0, 0)
+      bot.entity.onGround = false
+      return
+    }
+  }
+
+  function sendControlledHorsePackets () {
+    const vehicle = bot.vehicle
+    if (!vehicle || !horseCtx) return false
+
+    ensureVehicleRotationDefaults(vehicle)
+
+    const jumpRelease = pendingHorseJumpRelease
+    pendingHorseJumpRelease = null
+
+    if (jumpRelease?.released) {
+      bot._client.write('entity_action', {
+        entityId: bot.entity.id,
+        actionId: 5,
+        jumpBoost: jumpRelease.jumpBoost
+      })
+    }
+
+    const sideways = controlState.left ? 1 : controlState.right ? -1 : 0
+    const forward = (controlState.forward ? 1 : 0) - (controlState.back ? 1 : 0)
+    bot.moveVehicle(sideways, forward, controlState.jump)
+
+    const x = vehicle.position.x
+    const y = vehicle.position.y
+    const z = vehicle.position.z
+    const yaw = Math.fround(conv.toNotchianYaw(vehicle.yaw))
+    const pitch = Math.fround(conv.toNotchianPitch(vehicle.pitch))
+
+    if (![x, y, z, yaw, pitch].every(Number.isFinite)) {
+      disableHorsePhysicsWithLog('non-finite vehicle state')
+      return false
+    }
+
+    bot._client.write('vehicle_move', { x, y, z, yaw, pitch })
+    return true
   }
 
   function isBoatPhysicsVersion () {
@@ -597,9 +829,31 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     pendingBoatCorrection = correction
   })
 
+  bot.on('vehicleCorrection', (entity, correction) => {
+    if (!isHorsePhysicsVersion() || !isRideableHorseEntity(entity) || bot.vehicle !== entity) return
+    if (!isHorseController()) return
+
+    if (correction.kind === 'vehicle_move') {
+      const now = performance.now()
+      if (now - horseCorrectionWindowStart > HORSE_CORRECTION_WINDOW_MS) {
+        horseCorrectionWindowStart = now
+        horseCorrectionCount = 0
+      }
+      horseCorrectionCount++
+      if (horseCorrectionCount >= HORSE_CORRECTION_LIMIT) {
+        disableHorsePhysicsWithLog(`${HORSE_CORRECTION_LIMIT} server corrections within ${HORSE_CORRECTION_WINDOW_MS}ms`)
+      }
+    }
+
+    pendingHorseCorrection = correction
+  })
+
   bot.on('mount', () => {
     if (isBoatController()) {
       createBoatContext(bot.vehicle)
+    }
+    if (isHorseController()) {
+      createHorseContext(bot.vehicle)
     }
   })
 
@@ -607,12 +861,24 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     if (entity.id === boatVehicleId) {
       destroyBoatContext()
     }
+    if (entity.id === horseVehicleId) {
+      destroyHorseContext()
+    }
   })
 
   bot.on('dismount', (previousVehicle) => {
     destroyBoatContext()
-    if (previousVehicle?.name !== 'boat') return
-    offsetPlayerFromBoat(previousVehicle)
+    destroyHorseContext()
+    if (previousVehicle?.name === 'boat') {
+      offsetPlayerFromBoat(previousVehicle)
+    } else if (isRideableHorseEntity(previousVehicle)) {
+      offsetPlayerFromHorse(previousVehicle)
+    }
+  })
+
+  bot.on('entityAttributes', (entity) => {
+    if (!horseCtx || bot.vehicle !== entity || horseVehicleId !== entity.id) return
+    horseCtx.state.updateFromHorseEntity(entity)
   })
 
   bot.on('entityMoved', (entity) => {
@@ -631,13 +897,19 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     const timestep = physicsTimestep
     const onVehicle = bot.vehicle && bot.entity.vehicle
     const boatController = onVehicle && isBoatController()
+    const horseController = onVehicle && isHorseController()
 
     if (boatCtx && !boatController) {
       destroyBoatContext()
     }
+    if (horseCtx && !horseController) {
+      destroyHorseContext()
+    }
 
-    if (onVehicle && !boatController) {
+    if (onVehicle && !boatController && !horseController) {
       syncEntityWithVehicle()
+    } else if (horseController) {
+      syncEntityWithHorse()
     }
 
     if (bot.blockAt(bot.entity.position) == null) return
@@ -664,6 +936,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
 
     boatTickPacketsReady = false
+    horseTickPacketsReady = false
 
     if (bot.physicsEnabled && shouldUsePhysics) {
       if (boatController) {
@@ -692,6 +965,22 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
           syncEntityWithVehicle()
           clampPassengerYawRelativeToBoat()
+        }
+      } else if (horseController) {
+        if (ensureHorseContext()) {
+          applyPendingHorseCorrection()
+
+          if (!horsePhysicsDisabled) {
+            syncControlsToHorseState()
+            horsePhysics.simulate(horseCtx, world)
+            if (horseCtx.state.worldReady) {
+              horseCtx.state.applyToEntity(bot.vehicle)
+              horseTickPacketsReady = true
+              bot.emit('entityMoved', bot.vehicle)
+            }
+          }
+
+          syncEntityWithHorse()
         }
       } else if (!onVehicle) {
         ectx ??= EPhysicsCtx.FROM_BOT(physics, bot, settings)
@@ -794,7 +1083,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   function sendPacketSteerVehicle () {
     bot.vehicleMove ??= {
       forward: bot.controlState.forward ? 1 : bot.controlState.back ? -1 : 0,
-      sideways: bot.controlState.left ? -1 : bot.controlState.right ? 1 : 0,
+      sideways: bot.controlState.left ? 1 : bot.controlState.right ? -1 : 0,
       jump: bot.controlState.jump ? 1 : 0
     }
 
@@ -907,6 +1196,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     const onVehicle = !!bot.entity.vehicle
     const onBoat = bot.vehicle?.name === 'boat'
     const boatController = onVehicle && isBoatController()
+    const horseController = onVehicle && isHorseController()
     if (onBoat && !isBoatPhysicsVersion()) {
       bot._client.write('steer_boat', {
         leftPaddle: bot.controlState.left || bot.controlState.forward || bot.controlState.back,
@@ -940,6 +1230,10 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       if (boatController) {
         if (boatTickPacketsReady) {
           sendControlledBoatPackets()
+        }
+      } else if (horseController) {
+        if (horseTickPacketsReady) {
+          sendControlledHorsePackets()
         }
       } else if (isServerAuthoritativeMinecart(bot.vehicle)) {
         sendPacketSteerVehicle()
@@ -1344,6 +1638,15 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   // player position and look (clientbound)
   bot._client.on('position', (packet) => {
+    if (packet.dismountVehicle === true && bot.vehicle) {
+      const previousVehicle = bot.vehicle
+      bot.vehicle = null
+      delete bot.entity.vehicle
+      destroyBoatContext()
+      destroyHorseContext()
+      bot.emit('dismount', previousVehicle)
+    }
+
     bot.entity.height = 1.8
 
     const vel = bot.entity.velocity
@@ -1456,7 +1759,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   let respawnTimer = 0
   bot.on('mount', () => {
-    if (isBoatController() || isServerAuthoritativeMinecart(bot.vehicle)) {
+    if (isBoatController() || isHorseController() || isServerAuthoritativeMinecart(bot.vehicle)) {
       shouldUsePhysics = true
     } else {
       shouldUsePhysics = false
@@ -1464,14 +1767,19 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   })
   bot.on('death', () => {
     shouldUsePhysics = false
+    destroyBoatContext()
+    destroyHorseContext()
     respawnTimer = Date.now()
   })
   bot.on('respawn', () => {
     shouldUsePhysics = false
     destroyBoatContext()
+    destroyHorseContext()
   })
   bot.on('login', () => {
     shouldUsePhysics = false
+    destroyBoatContext()
+    destroyHorseContext()
   })
 
   function forceResetControls () {
@@ -1533,6 +1841,11 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     getCtx () { return boatCtx },
     isDisabled () { return boatPhysicsDisabled },
     getStatus () { return boatCtx?.state?.status ?? null }
+  }
+
+  bot._horsePhysics = {
+    getCtx () { return horseCtx },
+    isDisabled () { return horsePhysicsDisabled }
   }
 }
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -34,6 +34,7 @@ const BOAT_PHYSICS_VERSION = '1.17.1'
 const BOAT_CORRECTION_LIMIT = 3
 const BOAT_CORRECTION_WINDOW_MS = 1000
 const MAX_BOAT_PASSENGER_YAW_OFFSET = 105 * Math.PI / 180
+const BOAT_PHYS_DEBUG = !!process.env.BOAT_PHYS_DEBUG
 const MAX_VEHICLE_MOVE_COMPONENT = 0.9800000190734863
 
 function checkInputEquality (oldInput, newInput) {
@@ -155,6 +156,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   let boatCorrectionCount = 0
   let boatCorrectionWindowStart = 0
   let boatTickPacketsReady = false
+  /** @type {Record<string, number>} */
+  let boatDebugCorrectionCounts = {}
 
   let lastSent = {
     x: 0,
@@ -443,6 +446,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     ensureVehicleRotationDefaults(vehicle)
     const entityType = bot.registry.entitiesByName.boat
     const state = BoatState.CREATE_FROM_ENTITY(boatPhysics, vehicle, ControlStateHandler.COPY_BOT(bot))
+    state.controllingPlayer = true
     boatCtx = EPhysicsCtx.FROM_ENTITY_STATE(boatPhysics, state, entityType)
     boatVehicleId = vehicle.id
     resetBoatCorrectionTracking()
@@ -472,16 +476,42 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   function applyPendingBoatCorrection () {
-    if (!pendingBoatCorrection || !boatCtx || !bot.vehicle) return
+    if (!pendingBoatCorrection || !boatCtx || !bot.vehicle) return false
     const correction = pendingBoatCorrection
     pendingBoatCorrection = null
-    boatCtx.state.rebaseFromEntity(bot.vehicle, {
+
+    if (correction.kind !== 'vehicle_move') {
+      if (BOAT_PHYS_DEBUG) {
+        console.log(`[boat phys] ignoring correction kind=${correction.kind}`)
+      }
+      return false
+    }
+
+    const vehicle = bot.vehicle
+    const localPos = boatCtx.state.pos
+    const serverDx = vehicle.position.x - localPos.x
+    const serverDy = vehicle.position.y - localPos.y
+    const serverDz = vehicle.position.z - localPos.z
+    const horizontalDist = Math.sqrt(serverDx * serverDx + serverDz * serverDz)
+    const totalDist = Math.sqrt(serverDx * serverDx + serverDy * serverDy + serverDz * serverDz)
+
+    if (BOAT_PHYS_DEBUG) {
+      console.log(
+        `[boat phys] correction apply kind=${correction.kind} ` +
+        `serverDelta=(${serverDx.toFixed(3)},${serverDy.toFixed(3)},${serverDz.toFixed(3)}) ` +
+        `horiz=${horizontalDist.toFixed(3)} total=${totalDist.toFixed(3)}`
+      )
+    }
+
+    boatCtx.state.rebaseFromEntity(vehicle, {
       replaceVelocity: correction.replaceVelocity === true
     })
+    return true
   }
 
   function syncControlsToBoatState () {
     if (!boatCtx) return
+    boatCtx.state.controllingPlayer = true
     boatCtx.state.updateControls(ControlStateHandler.COPY_BOT(bot))
   }
 
@@ -526,6 +556,14 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   bot.on('vehicleCorrection', (entity, correction) => {
     if (!isBoatPhysicsVersion() || entity.name !== 'boat' || bot.vehicle !== entity) return
     if (!isBoatController()) return
+
+    if (BOAT_PHYS_DEBUG) {
+      boatDebugCorrectionCounts[correction.kind] = (boatDebugCorrectionCounts[correction.kind] || 0) + 1
+      console.log(
+        `[boat phys] correction received kind=${correction.kind} ` +
+        `count=${boatDebugCorrectionCounts[correction.kind]}`
+      )
+    }
 
     if (correction.kind === 'vehicle_move') {
       const now = performance.now()
@@ -601,7 +639,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     if (bot.physicsEnabled && shouldUsePhysics) {
       if (boatController) {
         if (ensureBoatContext()) {
-          applyPendingBoatCorrection()
+          const hadPendingCorrection = pendingBoatCorrection != null
+          const appliedCorrection = applyPendingBoatCorrection()
 
           if (!boatPhysicsDisabled) {
             syncControlsToBoatState()
@@ -611,6 +650,15 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
               boatTickPacketsReady = true
               bot.emit('entityMoved', bot.vehicle)
             }
+          }
+
+          if (BOAT_PHYS_DEBUG) {
+            const s = boatCtx.state
+            console.log(
+              `[boat phys] tick status=${s.status} prev=${s.previousStatus} ` +
+              `y=${s.pos.y.toFixed(3)} vel=(${s.vel.x.toFixed(4)},${s.vel.y.toFixed(4)},${s.vel.z.toFixed(4)}) ` +
+              `water=${s.waterLevel.toFixed(3)} pending=${hadPendingCorrection} applied=${appliedCorrection}`
+            )
           }
 
           syncEntityWithVehicle()

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -567,12 +567,16 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   function isHorsePhysicsVersion () {
-    return horseCapabilityAvailable && bot.version === HORSE_PHYSICS_VERSION
+    return bot.version === HORSE_PHYSICS_VERSION
+  }
+
+  function canUseLocalHorsePhysics () {
+    return horseCapabilityAvailable && isHorsePhysicsVersion()
   }
 
   function isHorseController () {
     const vehicle = bot.vehicle
-    return isHorsePhysicsVersion() &&
+    return canUseLocalHorsePhysics() &&
       vehicle &&
       isRideableHorseEntity(vehicle) &&
       vehicle.passengers?.[0]?.id === bot.entity.id &&
@@ -731,18 +735,22 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   function isBoatPhysicsVersion () {
-    return boatCapabilityAvailable && bot.version === BOAT_PHYSICS_VERSION
+    return bot.version === BOAT_PHYSICS_VERSION
+  }
+
+  function canUseLocalBoatPhysics () {
+    return boatCapabilityAvailable && isBoatPhysicsVersion()
   }
 
   function isBoatController () {
-    return isBoatPhysicsVersion() &&
+    return canUseLocalBoatPhysics() &&
       bot.vehicle?.name === 'boat' &&
       bot.vehicle.passengers?.[0]?.id === bot.entity.id
   }
 
   function needsLegacyBoatPackets () {
     const vehicle = bot.vehicle
-    return !isBoatPhysicsVersion() &&
+    return !canUseLocalBoatPhysics() &&
       vehicle?.name === 'boat' &&
       vehicle.passengers?.[0]?.id === bot.entity.id
   }
@@ -878,7 +886,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   bot.on('vehicleCorrection', (entity, correction) => {
-    if (!isBoatPhysicsVersion() || entity.name !== 'boat' || bot.vehicle !== entity) return
+    if (!canUseLocalBoatPhysics() || entity.name !== 'boat' || bot.vehicle !== entity) return
     if (!isBoatController()) return
 
     if (BOAT_PHYS_DEBUG) {
@@ -905,7 +913,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   })
 
   bot.on('vehicleCorrection', (entity, correction) => {
-    if (!isHorsePhysicsVersion() || !isRideableHorseEntity(entity) || bot.vehicle !== entity) return
+    if (!canUseLocalHorsePhysics() || !isRideableHorseEntity(entity) || bot.vehicle !== entity) return
     if (!isHorseController()) return
 
     if (correction.kind === 'vehicle_move') {
@@ -1295,7 +1303,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     const onBoat = bot.vehicle?.name === 'boat'
     const boatController = onVehicle && isBoatController()
     const horseController = onVehicle && isHorseController()
-    if (onBoat && !isBoatPhysicsVersion()) {
+    if (needsLegacyBoatPackets()) {
       bot._client.write('steer_boat', {
         leftPaddle: bot.controlState.left || bot.controlState.forward || bot.controlState.back,
         rightPaddle: bot.controlState.right || bot.controlState.forward || bot.controlState.back
@@ -1335,7 +1343,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
         }
       } else if (isServerAuthoritativeMinecart(bot.vehicle)) {
         sendPacketSteerVehicle()
-      } else if (!isBoatPhysicsVersion() || !onBoat) {
+      } else if (!canUseLocalBoatPhysics() || !onBoat) {
         sendPacketVehicleMove()
       }
     }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -25,6 +25,8 @@ const DEFAULT_PHYSICS_TIMESTEP = DEFAULT_PHYSICS_INTERVAL_MS / 1000
 // Vanilla LocalPlayer.sendPosition uses a 2.0E-4 squared-distance threshold,
 // not the server-side 0.03 movement lenience.
 const MIN_DELTA_DIST_SQUARED = 4.0E-8
+const BOAT_DISMOUNT_YAW_OFFSETS = [0, Math.PI / 8, -Math.PI / 8, Math.PI / 4, -Math.PI / 4]
+const MAX_BOAT_DISMOUNT_DISTANCE = 2.5
 
 function checkInputEquality (oldInput, newInput) {
   const oldKeys = Object.keys(oldInput)
@@ -311,8 +313,93 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
   }
 
+  function syncEntityWithVehicle () {
+    const vehicle = bot.vehicle
+    if (!vehicle) return
+
+    bot.entity.position.set(
+      vehicle.position.x,
+      vehicle.position.y + (vehicle.height ?? 0),
+      vehicle.position.z
+    )
+
+    const vehicleVelocity = vehicle.velocity
+    bot.entity.velocity.set(
+      vehicleVelocity?.x ?? 0,
+      vehicleVelocity?.y ?? 0,
+      vehicleVelocity?.z ?? 0
+    )
+    bot.entity.onGround = vehicle.onGround ?? false
+  }
+
+  function isSolidBlockAt (pos) {
+    const block = bot.blockAt(pos, false)
+    if (block == null) return false
+    if (block.type === 0 || block.name === 'air' || block.name === 'cave_air' || block.name === 'void_air') {
+      return false
+    }
+    return true
+  }
+
+  function isOutsideHorizontalEntityAabb (x, z, entity) {
+    const halfWidth = (entity.width ?? 0) / 2
+    if (halfWidth <= 0) return false
+    const dx = Math.abs(x - entity.position.x)
+    const dz = Math.abs(z - entity.position.z)
+    return dx > halfWidth || dz > halfWidth
+  }
+
+  function isValidBoatDismountPosition (x, y, z, boat) {
+    if (!isOutsideHorizontalEntityAabb(x, z, boat)) return false
+    if (isSolidBlockAt(new Vec3(x, y, z))) return false
+    if (isSolidBlockAt(new Vec3(x, y + 1, z))) return false
+    return true
+  }
+
+  function computeBoatDismountDistance (boat, player) {
+    const boatWidth = boat.width
+    const playerWidth = player.width
+    if (!boatWidth || !playerWidth || boatWidth <= 0 || playerWidth <= 0) return null
+    const distance = (boatWidth * Math.SQRT2 + playerWidth) / 2
+    return Math.min(distance, MAX_BOAT_DISMOUNT_DISTANCE)
+  }
+
+  function offsetPlayerFromBoat (boat) {
+    const distance = computeBoatDismountDistance(boat, bot.entity)
+    if (distance == null) return
+
+    const y = boat.position.y + (boat.height ?? 0)
+    const vehicleVelocity = boat.velocity
+
+    for (const yawOffset of BOAT_DISMOUNT_YAW_OFFSETS) {
+      const dirYaw = bot.entity.yaw + yawOffset
+      const x = boat.position.x - Math.sin(dirYaw) * distance
+      const z = boat.position.z - Math.cos(dirYaw) * distance
+      if (!isValidBoatDismountPosition(x, y, z, boat)) continue
+
+      bot.entity.position.set(x, y, z)
+      if (vehicleVelocity) {
+        bot.entity.velocity.set(vehicleVelocity.x, vehicleVelocity.y, vehicleVelocity.z)
+      } else {
+        bot.entity.velocity.set(0, 0, 0)
+      }
+      bot.entity.onGround = false
+      return
+    }
+  }
+
+  bot.on('dismount', (previousVehicle) => {
+    if (previousVehicle?.name !== 'boat') return
+    offsetPlayerFromBoat(previousVehicle)
+  })
+
   function tickPhysics (now) {
     const timestep = physicsTimestep
+    const onVehicle = bot.vehicle && bot.entity.vehicle
+
+    if (onVehicle) {
+      syncEntityWithVehicle()
+    }
 
     if (bot.blockAt(bot.entity.position) == null) return
 
@@ -338,21 +425,27 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
 
     if (bot.physicsEnabled && shouldUsePhysics) {
-      ectx ??= EPhysicsCtx.FROM_BOT(physics, bot, settings)
-      ectx.state.update(bot)
+      if (!onVehicle) {
+        ectx ??= EPhysicsCtx.FROM_BOT(physics, bot, settings)
+        ectx.state.update(bot)
 
-      ectx.state.yaw = lastSentYaw
-      ectx.state.pitch = lastSentPitch
+        // 2. Sync physics engine to the interpolated look to satisfy anticheats
+        ectx.state.yaw = lastSentYaw
+        ectx.state.pitch = lastSentPitch
 
-      Object.assign(ectx, settings.overrides)
+        Object.assign(ectx, settings.overrides)
 
-      const targetYaw = bot.entity.yaw
-      const targetPitch = bot.entity.pitch
+        // 3. Save target yaw/pitch before applying physics
+        const targetYaw = bot.entity.yaw
+        const targetPitch = bot.entity.pitch
 
-      physics.simulate(ectx, world).apply(bot)
-      bot.entity.yaw = targetYaw
-      bot.entity.pitch = targetPitch
-      bot.emit('entityPhysicsTick')
+        physics.simulate(ectx, world).apply(bot)
+
+        // 4. Restore target yaw/pitch so the bot doesn't forget where it's trying to look
+        bot.entity.yaw = targetYaw
+        bot.entity.pitch = targetPitch
+        bot.emit('entityPhysicsTick')
+      }
     }
 
     if (shouldUsePhysics) updatePosition(now)
@@ -455,8 +548,6 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       forward: 0,
       jump: 0
     }
-
-    bot.entity.position = bot.vehicle.position.offset(0, bot.vehicle.height, 0)
   }
 
   function isEntityRemoved () {
@@ -846,7 +937,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   bot.setControlState = (control, state) => {
-    if (control === 'sneak' && bot.vehicle) {
+    if (control === 'sneak' && state === true && bot.vehicle) {
       bot.dismount()
       return
     }
@@ -967,6 +1058,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSentPitch = bot.entity.pitch
   })
 
+  // player position and look (clientbound)
   bot._client.on('position', (packet) => {
     bot.entity.height = 1.8
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -705,6 +705,13 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       bot.vehicle.passengers?.[0]?.id === bot.entity.id
   }
 
+  function needsLegacyBoatPackets () {
+    const vehicle = bot.vehicle
+    return !isBoatPhysicsVersion() &&
+      vehicle?.name === 'boat' &&
+      vehicle.passengers?.[0]?.id === bot.entity.id
+  }
+
   function destroyBoatContext () {
     boatCtx = null
     boatVehicleId = null
@@ -1032,8 +1039,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
         // 4. Restore target yaw/pitch so the bot doesn't forget where it's trying to look
         bot.entity.yaw = targetYaw
         bot.entity.pitch = targetPitch
-        bot.emit('entityPhysicsTick')
       }
+
+      bot.emit('entityPhysicsTick')
     }
 
     if (shouldUsePhysics) updatePosition(now)
@@ -1138,8 +1146,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     const x = vehicle.position.x
     const y = vehicle.position.y
     const z = vehicle.position.z
-    const yaw = vehicle.yaw
-    const pitch = vehicle.pitch
+    const yaw = Math.fround(conv.toNotchianYaw(vehicle.yaw))
+    const pitch = Math.fround(conv.toNotchianPitch(vehicle.pitch))
     if (![x, y, z, yaw, pitch].every(Number.isFinite)) return
 
     bot._client.write('vehicle_move', { x, y, z, yaw, pitch })
@@ -1801,7 +1809,12 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   let respawnTimer = 0
   bot.on('mount', () => {
-    if (isBoatController() || isHorseController() || isServerAuthoritativeMinecart(bot.vehicle)) {
+    if (
+      isBoatController() ||
+      isHorseController() ||
+      needsLegacyBoatPackets() ||
+      isServerAuthoritativeMinecart(bot.vehicle)
+    ) {
       shouldUsePhysics = true
     } else {
       shouldUsePhysics = false

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -10,7 +10,10 @@ const {
   PhysicsWorldSettings,
   initSetup,
   convertPlayerState,
-  applyToPlayerState
+  applyToPlayerState,
+  BoatPhysics,
+  BoatState,
+  ControlStateHandler
 } = require('@nxg-org/mineflayer-physics-util')
 const { JavaFloat } = require('../javamath')
 
@@ -27,6 +30,11 @@ const DEFAULT_PHYSICS_TIMESTEP = DEFAULT_PHYSICS_INTERVAL_MS / 1000
 const MIN_DELTA_DIST_SQUARED = 4.0E-8
 const BOAT_DISMOUNT_YAW_OFFSETS = [0, Math.PI / 8, -Math.PI / 8, Math.PI / 4, -Math.PI / 4]
 const MAX_BOAT_DISMOUNT_DISTANCE = 2.5
+const BOAT_PHYSICS_VERSION = '1.17.1'
+const BOAT_CORRECTION_LIMIT = 3
+const BOAT_CORRECTION_WINDOW_MS = 1000
+const MAX_BOAT_PASSENGER_YAW_OFFSET = 105 * Math.PI / 180
+const MAX_VEHICLE_MOVE_COMPONENT = 0.9800000190734863
 
 function checkInputEquality (oldInput, newInput) {
   const oldKeys = Object.keys(oldInput)
@@ -97,6 +105,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   const world = { getBlock: (pos) => bot.blockAt(pos, false) }
 
   const physics = new BotcraftPhysics(bot.registry)
+  const boatPhysics = new BoatPhysics(bot.registry)
   initSetup(bot.registry)
 
   const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')
@@ -133,6 +142,19 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
    * @type {EPhysicsCtx<PlayerState> | undefined}
    */
   let ectx
+
+  /**
+   * @type {import('@nxg-org/mineflayer-physics-util').EPhysicsCtx<import('@nxg-org/mineflayer-physics-util').BoatState> | null}
+   */
+  let boatCtx = null
+  let boatVehicleId = null
+  let boatPhysicsDisabled = false
+  let boatPhysicsDisabledLogged = false
+  /** @type {{ kind: string, replaceVelocity: boolean } | null} */
+  let pendingBoatCorrection = null
+  let boatCorrectionCount = 0
+  let boatCorrectionWindowStart = 0
+  let boatTickPacketsReady = false
 
   let lastSent = {
     x: 0,
@@ -388,7 +410,152 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
   }
 
+  function isBoatPhysicsVersion () {
+    return bot.version === BOAT_PHYSICS_VERSION
+  }
+
+  function isBoatController () {
+    return isBoatPhysicsVersion() &&
+      bot.vehicle?.name === 'boat' &&
+      bot.vehicle.passengers?.[0] === bot.entity
+  }
+
+  function destroyBoatContext () {
+    boatCtx = null
+    boatVehicleId = null
+    pendingBoatCorrection = null
+    boatTickPacketsReady = false
+  }
+
+  function resetBoatCorrectionTracking () {
+    boatCorrectionCount = 0
+    boatCorrectionWindowStart = 0
+    boatPhysicsDisabled = false
+    boatPhysicsDisabledLogged = false
+  }
+
+  function ensureVehicleRotationDefaults (vehicle) {
+    if (!Number.isFinite(vehicle.yaw)) vehicle.yaw = 0
+    if (!Number.isFinite(vehicle.pitch)) vehicle.pitch = 0
+  }
+
+  function createBoatContext (vehicle) {
+    ensureVehicleRotationDefaults(vehicle)
+    const entityType = bot.registry.entitiesByName.boat
+    const state = BoatState.CREATE_FROM_ENTITY(boatPhysics, vehicle, ControlStateHandler.COPY_BOT(bot))
+    boatCtx = EPhysicsCtx.FROM_ENTITY_STATE(boatPhysics, state, entityType)
+    boatVehicleId = vehicle.id
+    resetBoatCorrectionTracking()
+    pendingBoatCorrection = null
+    boatTickPacketsReady = false
+  }
+
+  function ensureBoatContext () {
+    const vehicle = bot.vehicle
+    if (!vehicle || vehicle.name !== 'boat') {
+      destroyBoatContext()
+      return false
+    }
+    if (!boatCtx || boatVehicleId !== vehicle.id) {
+      createBoatContext(vehicle)
+    }
+    return true
+  }
+
+  function disableBoatPhysicsWithLog (reason) {
+    if (boatPhysicsDisabled) return
+    boatPhysicsDisabled = true
+    if (!boatPhysicsDisabledLogged) {
+      console.warn(`[mineflayer] disabled local boat physics: ${reason}`)
+      boatPhysicsDisabledLogged = true
+    }
+  }
+
+  function applyPendingBoatCorrection () {
+    if (!pendingBoatCorrection || !boatCtx || !bot.vehicle) return
+    const correction = pendingBoatCorrection
+    pendingBoatCorrection = null
+    boatCtx.state.rebaseFromEntity(bot.vehicle, {
+      replaceVelocity: correction.replaceVelocity === true
+    })
+  }
+
+  function syncControlsToBoatState () {
+    if (!boatCtx) return
+    boatCtx.state.updateControls(ControlStateHandler.COPY_BOT(bot))
+  }
+
+  function clampPassengerYawRelativeToBoat () {
+    const vehicle = bot.vehicle
+    if (!vehicle) return
+
+    let relativeYaw = bot.entity.yaw - vehicle.yaw
+    const fullTurn = Math.PI * 2
+    relativeYaw = ((relativeYaw + Math.PI) % fullTurn + fullTurn) % fullTurn - Math.PI
+    if (relativeYaw > MAX_BOAT_PASSENGER_YAW_OFFSET) {
+      bot.entity.yaw = vehicle.yaw + MAX_BOAT_PASSENGER_YAW_OFFSET
+    } else if (relativeYaw < -MAX_BOAT_PASSENGER_YAW_OFFSET) {
+      bot.entity.yaw = vehicle.yaw - MAX_BOAT_PASSENGER_YAW_OFFSET
+    }
+  }
+
+  function sendControlledBoatPackets () {
+    const vehicle = bot.vehicle
+    if (!vehicle || !boatCtx) return false
+
+    ensureVehicleRotationDefaults(vehicle)
+
+    const x = vehicle.position.x
+    const y = vehicle.position.y
+    const z = vehicle.position.z
+    const yaw = Math.fround(conv.toNotchianYaw(vehicle.yaw))
+    const pitch = Math.fround(conv.toNotchianPitch(vehicle.pitch))
+
+    if (![x, y, z, yaw, pitch].every(Number.isFinite)) {
+      disableBoatPhysicsWithLog('non-finite vehicle state')
+      return false
+    }
+
+    const paddles = boatPhysics.getPaddleState(boatCtx.state)
+    bot._client.write('steer_boat', paddles)
+    bot.moveVehicle(0, 0, false)
+    bot._client.write('vehicle_move', { x, y, z, yaw, pitch })
+    return true
+  }
+
+  bot.on('vehicleCorrection', (entity, correction) => {
+    if (!isBoatPhysicsVersion() || entity.name !== 'boat' || bot.vehicle !== entity) return
+    if (!isBoatController()) return
+
+    if (correction.kind === 'vehicle_move') {
+      const now = performance.now()
+      if (now - boatCorrectionWindowStart > BOAT_CORRECTION_WINDOW_MS) {
+        boatCorrectionWindowStart = now
+        boatCorrectionCount = 0
+      }
+      boatCorrectionCount++
+      if (boatCorrectionCount >= BOAT_CORRECTION_LIMIT) {
+        disableBoatPhysicsWithLog(`${BOAT_CORRECTION_LIMIT} server corrections within ${BOAT_CORRECTION_WINDOW_MS}ms`)
+      }
+    }
+
+    pendingBoatCorrection = correction
+  })
+
+  bot.on('mount', () => {
+    if (isBoatController()) {
+      createBoatContext(bot.vehicle)
+    }
+  })
+
+  bot.on('entityGone', (entity) => {
+    if (entity.id === boatVehicleId) {
+      destroyBoatContext()
+    }
+  })
+
   bot.on('dismount', (previousVehicle) => {
+    destroyBoatContext()
     if (previousVehicle?.name !== 'boat') return
     offsetPlayerFromBoat(previousVehicle)
   })
@@ -396,8 +563,13 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   function tickPhysics (now) {
     const timestep = physicsTimestep
     const onVehicle = bot.vehicle && bot.entity.vehicle
+    const boatController = onVehicle && isBoatController()
 
-    if (onVehicle) {
+    if (boatCtx && !boatController) {
+      destroyBoatContext()
+    }
+
+    if (onVehicle && !boatController) {
       syncEntityWithVehicle()
     }
 
@@ -424,8 +596,27 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       lastSentPitch += math.clamp(-maxDeltaPitch, dPitch, maxDeltaPitch)
     }
 
+    boatTickPacketsReady = false
+
     if (bot.physicsEnabled && shouldUsePhysics) {
-      if (!onVehicle) {
+      if (boatController) {
+        if (ensureBoatContext()) {
+          applyPendingBoatCorrection()
+
+          if (!boatPhysicsDisabled) {
+            syncControlsToBoatState()
+            boatPhysics.simulate(boatCtx, world)
+            if (boatCtx.state.worldReady) {
+              boatCtx.state.applyToEntity(bot.vehicle)
+              boatTickPacketsReady = true
+              bot.emit('entityMoved', bot.vehicle)
+            }
+          }
+
+          syncEntityWithVehicle()
+          clampPassengerYawRelativeToBoat()
+        }
+      } else if (!onVehicle) {
         ectx ??= EPhysicsCtx.FROM_BOT(physics, bot, settings)
         ectx.state.update(bot)
 
@@ -453,7 +644,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     // move this afterward to sync inputs.
     if (bot.physicsEnabled && shouldUsePhysics) {
       bot.emit('physicsTick')
-      bot.emit('physicTick')
+      bot.emit('physicTick') // Deprecated, only exists to support old plugins. May be removed in the future
     }
 
     if (bot.registry.isNewerOrEqualTo('1.21.3')) {
@@ -531,7 +722,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
 
     for (const key of Object.keys(bot.vehicleMove)) {
-      bot.vehicleMove[key] = Math.min(Math.abs(bot.vehicleMove[key]), 0.9800000190734863) * Math.sign(bot.vehicleMove[key])
+      bot.vehicleMove[key] = Math.min(Math.abs(bot.vehicleMove[key]), MAX_VEHICLE_MOVE_COMPONENT) * Math.sign(bot.vehicleMove[key])
     }
 
     bot.moveVehicle(bot.vehicleMove.sideways, bot.vehicleMove.forward, bot.vehicleMove.jump)
@@ -631,7 +822,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
     const onVehicle = !!bot.entity.vehicle
     const onBoat = bot.vehicle?.name === 'boat'
-    if (onBoat) {
+    const boatController = onVehicle && isBoatController()
+    if (onBoat && !isBoatPhysicsVersion()) {
       bot._client.write('steer_boat', {
         leftPaddle: bot.controlState.left || bot.controlState.forward || bot.controlState.back,
         rightPaddle: bot.controlState.right || bot.controlState.forward || bot.controlState.back
@@ -661,7 +853,13 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
 
     if (onVehicle) {
-      sendPacketVehicleMove(position)
+      if (boatController) {
+        if (boatTickPacketsReady) {
+          sendControlledBoatPackets()
+        }
+      } else if (!isBoatPhysicsVersion() || !onBoat) {
+        sendPacketVehicleMove(position)
+      }
     }
 
     if (lookUpdated) {
@@ -1176,7 +1374,10 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     shouldUsePhysics = false
     respawnTimer = Date.now()
   })
-  bot.on('respawn', () => { shouldUsePhysics = false })
+  bot.on('respawn', () => {
+    shouldUsePhysics = false
+    destroyBoatContext()
+  })
   bot.on('login', () => {
     shouldUsePhysics = false
   })
@@ -1235,6 +1436,11 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     clearPendingElytraFly(new Error('Elytra flight cancelled due to disconnect'))
     cleanup()
   })
+
+  bot._boatPhysics = {
+    getCtx () { return boatCtx },
+    isDisabled () { return boatPhysicsDisabled }
+  }
 }
 
 module.exports = inject

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -157,7 +157,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   let boatCorrectionWindowStart = 0
   let boatTickPacketsReady = false
   /** @type {Record<string, number>} */
-  let boatDebugCorrectionCounts = {}
+  const boatDebugCorrectionCounts = {}
 
   let lastSent = {
     x: 0,
@@ -1417,7 +1417,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   let respawnTimer = 0
-  bot.on('mount', () => { shouldUsePhysics = false })
+  bot.on('mount', () => {
+    if (!isBoatController()) shouldUsePhysics = false
+  })
   bot.on('death', () => {
     shouldUsePhysics = false
     respawnTimer = Date.now()

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -1487,7 +1487,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   bot._boatPhysics = {
     getCtx () { return boatCtx },
-    isDisabled () { return boatPhysicsDisabled }
+    isDisabled () { return boatPhysicsDisabled },
+    getStatus () { return boatCtx?.state?.status ?? null }
   }
 }
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -417,7 +417,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   function isBoatController () {
     return isBoatPhysicsVersion() &&
       bot.vehicle?.name === 'boat' &&
-      bot.vehicle.passengers?.[0] === bot.entity
+      bot.vehicle.passengers?.[0]?.id === bot.entity.id
   }
 
   function destroyBoatContext () {

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -890,6 +890,16 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   bot.on('mount', () => {
     clearPendingPostDismount()
+
+    const vehicle = bot.vehicle
+    if (isHorsePhysicsVersion() && isRideableHorseEntity(vehicle)) {
+      const oldPos = bot.entity.position.clone()
+      syncEntityWithHorse()
+      if (!bot.entity.position.equals(oldPos)) {
+        bot.emit('move', oldPos)
+      }
+    }
+
     if (isBoatController()) {
       createBoatContext(bot.vehicle)
     }
@@ -944,10 +954,17 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       destroyHorseContext()
     }
 
-    if (onVehicle && !boatController && !horseController) {
-      syncEntityWithVehicle()
-    } else if (horseController) {
-      syncEntityWithHorse()
+    const horsePassengerSync =
+      onVehicle &&
+      isHorsePhysicsVersion() &&
+      isRideableHorseEntity(bot.vehicle)
+
+    if (onVehicle && !boatController) {
+      if (horsePassengerSync) {
+        syncEntityWithHorse()
+      } else {
+        syncEntityWithVehicle()
+      }
     }
 
     if (bot.blockAt(bot.entity.position) == null) return

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -1912,7 +1912,10 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   bot._boatPhysics = {
     getCtx () { return boatCtx },
     isDisabled () { return boatPhysicsDisabled },
-    getStatus () { return boatCtx?.state?.status ?? null }
+    getStatus () { return boatCtx?.state?.status ?? null },
+    getPaddleState () {
+      return boatCtx ? boatPhysics.getPaddleState(boatCtx.state) : null
+    }
   }
 
   bot._horsePhysics = {

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -4,6 +4,7 @@ const conv = require('../conversions')
 const math = require('../math')
 const { performance } = require('perf_hooks')
 const { createDoneTask, createTask } = require('../promise_utils')
+const physicsUtil = require('@nxg-org/mineflayer-physics-util')
 const {
   BotcraftPhysics,
   EPhysicsCtx,
@@ -16,7 +17,8 @@ const {
   HorsePhysics,
   HorseState,
   ControlStateHandler
-} = require('@nxg-org/mineflayer-physics-util')
+} = physicsUtil
+const { resolveTransportPhysicsCapabilities } = require('../physicsCapabilities')
 const { JavaFloat } = require('../javamath')
 
 const mouseSensitivity = 100.0
@@ -145,9 +147,15 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   const PHYSICS_CATCHUP_TICKS = maxCatchupTicks ?? 4
   const world = { getBlock: (pos) => bot.blockAt(pos, false) }
 
+  const transportCapabilities = resolveTransportPhysicsCapabilities(physicsUtil)
+  const boatCapabilityAvailable = transportCapabilities.boat
+  const horseCapabilityAvailable = transportCapabilities.horse
+  let warnedMissingBoatCapability = false
+  let warnedMissingHorseCapability = false
+
   const physics = new BotcraftPhysics(bot.registry)
-  const boatPhysics = new BoatPhysics(bot.registry)
-  const horsePhysics = new HorsePhysics(bot.registry)
+  const boatPhysics = boatCapabilityAvailable ? new BoatPhysics(bot.registry) : null
+  const horsePhysics = horseCapabilityAvailable ? new HorsePhysics(bot.registry) : null
   initSetup(bot.registry)
 
   const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')
@@ -531,8 +539,35 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
   }
 
+  function warnMissingBoatCapabilityOnce () {
+    if (warnedMissingBoatCapability || boatCapabilityAvailable) return
+    warnedMissingBoatCapability = true
+    console.warn('[mineflayer] local boat physics unavailable: @nxg-org/mineflayer-physics-util does not export BoatPhysics/BoatState')
+  }
+
+  function warnMissingHorseCapabilityOnce () {
+    if (warnedMissingHorseCapability || horseCapabilityAvailable) return
+    warnedMissingHorseCapability = true
+    console.warn('[mineflayer] local horse physics unavailable: @nxg-org/mineflayer-physics-util does not export HorsePhysics/HorseState')
+  }
+
+  function isBoatControllerCandidate () {
+    return bot.version === BOAT_PHYSICS_VERSION &&
+      bot.vehicle?.name === 'boat' &&
+      bot.vehicle.passengers?.[0]?.id === bot.entity.id
+  }
+
+  function isHorseControllerCandidate () {
+    const vehicle = bot.vehicle
+    return bot.version === HORSE_PHYSICS_VERSION &&
+      vehicle &&
+      isRideableHorseEntity(vehicle) &&
+      vehicle.passengers?.[0]?.id === bot.entity.id &&
+      horseSaddleFlag(vehicle)
+  }
+
   function isHorsePhysicsVersion () {
-    return bot.version === HORSE_PHYSICS_VERSION
+    return horseCapabilityAvailable && bot.version === HORSE_PHYSICS_VERSION
   }
 
   function isHorseController () {
@@ -696,7 +731,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   function isBoatPhysicsVersion () {
-    return bot.version === BOAT_PHYSICS_VERSION
+    return boatCapabilityAvailable && bot.version === BOAT_PHYSICS_VERSION
   }
 
   function isBoatController () {
@@ -892,6 +927,13 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     clearPendingPostDismount()
 
     const vehicle = bot.vehicle
+    if (isBoatControllerCandidate() && !boatCapabilityAvailable) {
+      warnMissingBoatCapabilityOnce()
+    }
+    if (isHorseControllerCandidate() && !horseCapabilityAvailable) {
+      warnMissingHorseCapabilityOnce()
+    }
+
     if (isHorsePhysicsVersion() && isRideableHorseEntity(vehicle)) {
       const oldPos = bot.entity.position.clone()
       syncEntityWithHorse()
@@ -1914,7 +1956,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     isDisabled () { return boatPhysicsDisabled },
     getStatus () { return boatCtx?.state?.status ?? null },
     getPaddleState () {
-      return boatCtx ? boatPhysics.getPaddleState(boatCtx.state) : null
+      return boatCtx && boatPhysics ? boatPhysics.getPaddleState(boatCtx.state) : null
     }
   }
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -58,6 +58,7 @@ const RIDEABLE_HORSE_ENTITY_NAMES = new Set([
   'zombie_horse'
 ])
 const HORSE_DISMOUNT_YAW_OFFSETS = [Math.PI / 2, -Math.PI / 2, 0, Math.PI / 8, -Math.PI / 8]
+const POST_DISMOUNT_TIMEOUT_MS = 3000
 
 function isRideableMinecartEntity (entity) {
   return entity != null && RIDEABLE_MINECART_ENTITY_NAMES.has(entity.name)
@@ -474,6 +475,38 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     return Math.min(distance, MAX_BOAT_DISMOUNT_DISTANCE)
   }
 
+  let pendingPostDismountVehicle = null
+  let pendingPostDismountAt = 0
+
+  function clearPendingPostDismount () {
+    pendingPostDismountVehicle = null
+    pendingPostDismountAt = 0
+  }
+
+  function isPendingPostDismountValid () {
+    if (pendingPostDismountVehicle == null) return false
+    if (Date.now() - pendingPostDismountAt >= POST_DISMOUNT_TIMEOUT_MS) {
+      clearPendingPostDismount()
+      return false
+    }
+    return true
+  }
+
+  function rememberPendingPostDismount (vehicle) {
+    if (vehicle?.name === 'boat' || isRideableHorseEntity(vehicle)) {
+      pendingPostDismountVehicle = vehicle
+      pendingPostDismountAt = Date.now()
+    }
+  }
+
+  function applyPostDismountOffset (vehicle) {
+    if (vehicle?.name === 'boat') {
+      offsetPlayerFromBoat(vehicle)
+    } else if (isRideableHorseEntity(vehicle)) {
+      offsetPlayerFromHorse(vehicle)
+    }
+  }
+
   function offsetPlayerFromBoat (boat) {
     const distance = computeBoatDismountDistance(boat, bot.entity)
     if (distance == null) return
@@ -849,6 +882,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   })
 
   bot.on('mount', () => {
+    clearPendingPostDismount()
     if (isBoatController()) {
       createBoatContext(bot.vehicle)
     }
@@ -869,11 +903,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   bot.on('dismount', (previousVehicle) => {
     destroyBoatContext()
     destroyHorseContext()
-    if (previousVehicle?.name === 'boat') {
-      offsetPlayerFromBoat(previousVehicle)
-    } else if (isRideableHorseEntity(previousVehicle)) {
-      offsetPlayerFromHorse(previousVehicle)
-    }
+    rememberPendingPostDismount(previousVehicle)
+    applyPostDismountOffset(previousVehicle)
   })
 
   bot.on('entityAttributes', (entity) => {
@@ -1638,6 +1669,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   // player position and look (clientbound)
   bot._client.on('position', (packet) => {
+    const shouldReapplyPostDismountOffset = packet.dismountVehicle === true
+
     if (packet.dismountVehicle === true && bot.vehicle) {
       const previousVehicle = bot.vehicle
       bot.vehicle = null
@@ -1725,6 +1758,15 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
 
     sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround)
+
+    if (shouldReapplyPostDismountOffset && bot.vehicle == null && isPendingPostDismountValid()) {
+      const vehicle = pendingPostDismountVehicle
+      const packetStillOnBoat = vehicle?.name === 'boat' &&
+        !isOutsideHorizontalEntityAabb(pos.x, pos.z, vehicle)
+      if (packetStillOnBoat) {
+        applyPostDismountOffset(vehicle)
+      }
+    }
 
     shouldUsePhysics = true
     bot.jumpTicks = 0

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -36,6 +36,23 @@ const BOAT_CORRECTION_WINDOW_MS = 1000
 const MAX_BOAT_PASSENGER_YAW_OFFSET = 105 * Math.PI / 180
 const BOAT_PHYS_DEBUG = !!process.env.BOAT_PHYS_DEBUG
 const MAX_VEHICLE_MOVE_COMPONENT = 0.9800000190734863
+const RIDEABLE_MINECART_ENTITY_NAMES = new Set([
+  'minecart',
+  'chest_minecart',
+  'furnace_minecart',
+  'hopper_minecart',
+  'tnt_minecart',
+  'spawner_minecart',
+  'command_block_minecart'
+])
+
+function isRideableMinecartEntity (entity) {
+  return entity != null && RIDEABLE_MINECART_ENTITY_NAMES.has(entity.name)
+}
+
+function isServerAuthoritativeMinecart (vehicle) {
+  return isRideableMinecartEntity(vehicle)
+}
 
 function checkInputEquality (oldInput, newInput) {
   const oldKeys = Object.keys(oldInput)
@@ -598,6 +615,18 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     offsetPlayerFromBoat(previousVehicle)
   })
 
+  bot.on('entityMoved', (entity) => {
+    if (bot.vehicle !== entity) return
+    if (!isServerAuthoritativeMinecart(entity)) return
+
+    const oldPos = bot.entity.position.clone()
+    syncEntityWithVehicle()
+
+    if (!bot.entity.position.equals(oldPos)) {
+      bot.emit('move', oldPos)
+    }
+  })
+
   function tickPhysics (now) {
     const timestep = physicsTimestep
     const onVehicle = bot.vehicle && bot.entity.vehicle
@@ -762,7 +791,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     bot.emit('move', oldPos)
   }
 
-  function sendPacketVehicleMove (position) {
+  function sendPacketSteerVehicle () {
     bot.vehicleMove ??= {
       forward: bot.controlState.forward ? 1 : bot.controlState.back ? -1 : 0,
       sideways: bot.controlState.left ? -1 : bot.controlState.right ? 1 : 0,
@@ -774,19 +803,26 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
 
     bot.moveVehicle(bot.vehicleMove.sideways, bot.vehicleMove.forward, bot.vehicleMove.jump)
-    bot._client.write('vehicle_move', {
-      x: bot.vehicle.position.x,
-      y: bot.vehicle.position.y,
-      z: bot.vehicle.position.z,
-      yaw: bot.vehicle.yaw,
-      pitch: bot.vehicle.pitch
-    })
 
     bot.vehicleMove = {
       sideways: 0,
       forward: 0,
       jump: 0
     }
+  }
+
+  function sendPacketVehicleMove () {
+    sendPacketSteerVehicle()
+
+    const vehicle = bot.vehicle
+    const x = vehicle.position.x
+    const y = vehicle.position.y
+    const z = vehicle.position.z
+    const yaw = vehicle.yaw
+    const pitch = vehicle.pitch
+    if (![x, y, z, yaw, pitch].every(Number.isFinite)) return
+
+    bot._client.write('vehicle_move', { x, y, z, yaw, pitch })
   }
 
   function isEntityRemoved () {
@@ -905,8 +941,10 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
         if (boatTickPacketsReady) {
           sendControlledBoatPackets()
         }
+      } else if (isServerAuthoritativeMinecart(bot.vehicle)) {
+        sendPacketSteerVehicle()
       } else if (!isBoatPhysicsVersion() || !onBoat) {
-        sendPacketVehicleMove(position)
+        sendPacketVehicleMove()
       }
     }
 
@@ -1418,7 +1456,11 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   let respawnTimer = 0
   bot.on('mount', () => {
-    if (!isBoatController()) shouldUsePhysics = false
+    if (isBoatController() || isServerAuthoritativeMinecart(bot.vehicle)) {
+      shouldUsePhysics = true
+    } else {
+      shouldUsePhysics = false
+    }
   })
   bot.on('death', () => {
     shouldUsePhysics = false

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -66,6 +66,19 @@ function isRideableMinecartEntity (entity) {
   return entity != null && RIDEABLE_MINECART_ENTITY_NAMES.has(entity.name)
 }
 
+function isBoatEntity (entity) {
+  const name = entity?.name?.toLowerCase()
+  if (!name) return false
+  return name === 'boat' || name === 'chest_boat' || name.endsWith('_boat') || name.endsWith('_raft')
+}
+
+// Bamboo rafts became a separate entity type in 1.21.2. Before that, a raft was
+// a 'boat' entity with a metadata variant that this project does not read.
+function isRaftEntity (entity) {
+  const name = entity?.name?.toLowerCase()
+  return typeof name === 'string' && name.endsWith('_raft')
+}
+
 function isRideableHorseEntity (entity) {
   return entity != null && RIDEABLE_HORSE_ENTITY_NAMES.has(entity.name)
 }
@@ -413,6 +426,47 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     return height * 0.75 - variantOffset - 0.35
   }
 
+  // <= 1.20.1: Entity#positionRider = y + vehicle.getPassengersRidingOffset() + passenger.getMyRidingOffset()
+  // Vanilla 1.17.1 sources: vehicle/Boat#getPassengersRidingOffset() = -0.1,
+  // vehicle/AbstractMinecart#getPassengersRidingOffset() = 0, player/Player#getMyRidingOffset() = -0.35.
+  const LEGACY_PLAYER_RIDING_OFFSET_Y = -0.35 // Player#getMyRidingOffset(), <= 1.20.1
+  const LEGACY_BOAT_RIDING_OFFSET_Y = -0.1 // Boat#getPassengersRidingOffset(), <= 1.20.1
+  const LEGACY_MINECART_RIDING_OFFSET_Y = 0 // AbstractMinecart#getPassengersRidingOffset(), <= 1.20.1
+
+  // >= 1.20.2: y is based on the vehicle's PASSENGER attachment point.
+  // The player's contribution is numerically the same, but the mechanism changed:
+  //   1.20.2-1.20.4: PASSENGER.y + Player#ridingOffset() (-0.6)
+  //   >= 1.20.5:     PASSENGER.y - Player.DEFAULT_VEHICLE_ATTACHMENT.y (0.6)
+  // Vanilla sources: Entity#positionRider, Boat#getPassengerAttachmentPoint,
+  // EntityType.*_MINECART#passengerAttachments and Player#ridingOffset / DEFAULT_VEHICLE_ATTACHMENT.
+  const MODERN_PLAYER_RIDING_OFFSET_Y = -0.6
+  const MODERN_MINECART_PASSENGER_ATTACHMENT_Y = 0.1875 // EntityType.*_MINECART.passengerAttachments()
+  const MODERN_BOAT_RIDE_HEIGHT_FACTOR = 1 / 3 // (Abstract)Boat#rideHeight(), >= 1.20.2
+  const MODERN_RAFT_RIDE_HEIGHT_FACTOR = 0.8888889 // Raft#rideHeight(), >= 1.21.2
+
+  /**
+   * Vanilla seat offset for a player passenger in a boat or minecart.
+   * Returns null for other vehicles so their existing behavior is preserved.
+   */
+  function getVehiclePassengerFeetOffsetY (vehicle) {
+    const isBoat = isBoatEntity(vehicle)
+    const isMinecart = isRideableMinecartEntity(vehicle)
+    if (!isBoat && !isMinecart) return null
+
+    const height = vehicle.height ?? 0
+
+    if (bot.registry.isNewerOrEqualTo('1.20.2')) {
+      const passengerAttachmentY = isBoat
+        ? height * (isRaftEntity(vehicle) ? MODERN_RAFT_RIDE_HEIGHT_FACTOR : MODERN_BOAT_RIDE_HEIGHT_FACTOR)
+        : MODERN_MINECART_PASSENGER_ATTACHMENT_Y
+      return passengerAttachmentY + MODERN_PLAYER_RIDING_OFFSET_Y
+    }
+
+    // Before 1.21.2 a raft was named 'boat'; its metadata variant is not read here.
+    const vehicleRidingOffset = isBoat ? LEGACY_BOAT_RIDING_OFFSET_Y : LEGACY_MINECART_RIDING_OFFSET_Y
+    return vehicleRidingOffset + LEGACY_PLAYER_RIDING_OFFSET_Y
+  }
+
   function syncEntityWithHorse () {
     const vehicle = bot.vehicle
     if (!vehicle) return
@@ -438,7 +492,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
     bot.entity.position.set(
       vehicle.position.x,
-      vehicle.position.y + (vehicle.height ?? 0),
+      // Boats and minecarts use vanilla seat offsets. Other vehicles retain the
+      // existing behavior; see the separate issue for non-1.17.1 horse physics.
+      vehicle.position.y + (getVehiclePassengerFeetOffsetY(vehicle) ?? (vehicle.height ?? 0)),
       vehicle.position.z
     )
 
@@ -942,12 +998,14 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       warnMissingHorseCapabilityOnce()
     }
 
+    const oldPos = bot.entity.position.clone()
     if (isHorsePhysicsVersion() && isRideableHorseEntity(vehicle)) {
-      const oldPos = bot.entity.position.clone()
       syncEntityWithHorse()
-      if (!bot.entity.position.equals(oldPos)) {
-        bot.emit('move', oldPos)
-      }
+    } else if (isBoatEntity(vehicle) || isRideableMinecartEntity(vehicle)) {
+      syncEntityWithVehicle()
+    }
+    if (!bot.entity.position.equals(oldPos)) {
+      bot.emit('move', oldPos)
     }
 
     if (isBoatController()) {

--- a/test/entityLookTest.js
+++ b/test/entityLookTest.js
@@ -1,0 +1,140 @@
+/* eslint-env mocha */
+
+const mineflayer = require('../')
+const mc = require('minecraft-protocol')
+const conv = require('../lib/conversions')
+const assert = require('assert')
+
+describe('mineflayer_entity_look 1.17.1v', function () {
+  this.timeout(10 * 1000)
+
+  const supportedVersion = '1.17.1'
+  const registry = require('prismarine-registry')(supportedVersion)
+  let bot
+  let server
+
+  beforeEach((done) => {
+    server = mc.createServer({
+      'online-mode': false,
+      version: supportedVersion,
+      port: 25572
+    })
+    server.on('listening', () => {
+      bot = mineflayer.createBot({
+        username: 'player',
+        version: supportedVersion,
+        port: 25572
+      })
+      done()
+    })
+  })
+
+  afterEach((done) => {
+    bot.on('end', () => done())
+    server.close()
+  })
+
+  function loginBot (client) {
+    client.write('login', (() => {
+      const loginPacket = registry.loginPacket
+      loginPacket.entityId = 0
+      return loginPacket
+    })())
+    client.write('position', {
+      x: 0,
+      y: 64,
+      z: 0,
+      yaw: 0,
+      pitch: 0,
+      flags: { x: false, y: false, z: false, yaw: false, pitch: false },
+      teleportId: 1
+    })
+  }
+
+  function ensureEntity (entityId) {
+    if (!bot.entities[entityId]) {
+      bot._client.emit('rel_entity_move', { entityId, dX: 0, dY: 0, dZ: 0 })
+    }
+    return bot.entities[entityId]
+  }
+
+  it('updates pitch when yaw byte is 0', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', () => {
+        const entityId = 200
+        const entity = ensureEntity(entityId)
+        entity.yaw = 1.25
+        entity.pitch = 0
+
+        bot._client.emit('entity_look', { entityId, yaw: 0, pitch: 64 })
+
+        assert.strictEqual(entity.yaw, conv.fromNotchianYawByte(0))
+        assert.strictEqual(entity.pitch, conv.fromNotchianPitchByte(64))
+        assert.ok(Number.isFinite(entity.pitch))
+        assert.notStrictEqual(entity.pitch, 0)
+        done()
+      })
+      loginBot(client)
+    })
+  })
+
+  it('updates yaw and zero pitch when pitch byte is 0', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', () => {
+        const entityId = 201
+        const entity = ensureEntity(entityId)
+        entity.yaw = 0
+        entity.pitch = 0.75
+
+        bot._client.emit('entity_look', { entityId, yaw: 64, pitch: 0 })
+
+        assert.strictEqual(entity.yaw, conv.fromNotchianYawByte(64))
+        assert.strictEqual(entity.pitch, conv.fromNotchianPitchByte(0))
+        assert.strictEqual(entity.pitch, 0)
+        done()
+      })
+      loginBot(client)
+    })
+  })
+
+  it('does not write NaN when yaw or pitch is missing', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', () => {
+        const entityId = 202
+        const entity = ensureEntity(entityId)
+        entity.yaw = 0.5
+        entity.pitch = -0.25
+
+        bot._client.emit('entity_look', { entityId, yaw: null, pitch: 32 })
+        assert.strictEqual(entity.yaw, 0.5)
+        assert.strictEqual(entity.pitch, -0.25)
+
+        bot._client.emit('entity_look', { entityId, yaw: 32, pitch: null })
+        assert.strictEqual(entity.yaw, 0.5)
+        assert.strictEqual(entity.pitch, -0.25)
+        done()
+      })
+      loginBot(client)
+    })
+  })
+
+  it('emits entityMoved after rotation update', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', () => {
+        const entityId = 203
+        ensureEntity(entityId)
+        let movedEntity = null
+        bot.once('entityMoved', (entity) => {
+          if (entity.id === entityId) movedEntity = entity
+        })
+
+        bot._client.emit('entity_look', { entityId, yaw: 0, pitch: 48 })
+
+        assert.strictEqual(movedEntity?.id, entityId)
+        assert.strictEqual(movedEntity.pitch, conv.fromNotchianPitchByte(48))
+        done()
+      })
+      loginBot(client)
+    })
+  })
+})

--- a/test/entityLookTest.js
+++ b/test/entityLookTest.js
@@ -97,6 +97,27 @@ describe('mineflayer_entity_look 1.17.1v', function () {
     })
   })
 
+  it('stores entity head rotation as headYaw without changing pitch', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', () => {
+        const entityId = 204
+        const entity = ensureEntity(entityId)
+        entity.pitch = 0.75
+
+        bot.once('entityMoved', (movedEntity, updateInfo) => {
+          assert.strictEqual(movedEntity, entity)
+          assert.deepStrictEqual(updateInfo, { headRotationOnly: true })
+        })
+        bot._client.emit('entity_head_rotation', { entityId, headYaw: 64 })
+
+        assert.strictEqual(entity.headYaw, conv.fromNotchianYawByte(64))
+        assert.strictEqual(entity.pitch, 0.75)
+        done()
+      })
+      loginBot(client)
+    })
+  })
+
   it('does not write NaN when yaw or pitch is missing', (done) => {
     server.on('playerJoin', (client) => {
       bot.once('login', () => {

--- a/test/entityPhysicsHorseTest.js
+++ b/test/entityPhysicsHorseTest.js
@@ -1,0 +1,223 @@
+/* eslint-env mocha */
+
+const mineflayer = require('../')
+const mc = require('minecraft-protocol')
+const vec3 = require('vec3')
+const assert = require('assert')
+const { once } = require('../lib/promise_utils')
+const { isRideableHorseEntityName } = require('../lib/plugins/entity_physics')
+
+function createBlockWorldStub (version, groundY = 63) {
+  const mcData = require('minecraft-data')(version)
+  const Block = require('prismarine-block')(version)
+  const stoneId = mcData.blocksByName.stone.id
+  const airId = mcData.blocksByName.air.id
+  const cache = new Map()
+
+  return (pos) => {
+    const blockPos = pos.floored()
+    const key = `${blockPos.x},${blockPos.y},${blockPos.z}`
+    const cached = cache.get(key)
+    if (cached) return cached
+
+    const type = blockPos.y < groundY ? stoneId : airId
+    const block = new Block(type, 0, 0)
+    block.position = blockPos
+    cache.set(key, block)
+    return block
+  }
+}
+
+function stubLoadedWorld (bot, groundY = 63) {
+  bot.blockAt = createBlockWorldStub(bot.version, groundY)
+}
+
+function loginBot (bot, client) {
+  client.write('login', bot.test.generateLoginPacket())
+  client.write('position', {
+    x: 0,
+    y: 64,
+    z: 0,
+    yaw: 0,
+    pitch: 0,
+    flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+    teleportId: 1
+  })
+}
+
+function makeRegistryEntity (bot, id, name, position, velocity) {
+  const entityTypeData = bot.registry.entitiesByName[name]
+  assert(entityTypeData, `expected registry entity for ${name}`)
+  return {
+    id,
+    name,
+    type: entityTypeData.type,
+    entityType: entityTypeData.id,
+    position: position.clone(),
+    velocity: velocity.clone(),
+    height: name === 'pig' ? 0.9 : 1.6,
+    width: name === 'pig' ? 0.9 : 1.3964844,
+    metadata: new Array(20).fill(0),
+    effects: [],
+    equipment: [],
+    isValid: true
+  }
+}
+
+function withLogin (bot, client, done, runTest) {
+  bot.once('login', async () => {
+    try {
+      await once(bot, 'forcedMove')
+      await runTest()
+      done()
+    } catch (err) {
+      done(err)
+    }
+  })
+  loginBot(bot, client)
+}
+
+function setupBotTest (supportedVersion, port) {
+  const registry = require('prismarine-registry')(supportedVersion)
+  const server = mc.createServer({
+    'online-mode': false,
+    version: supportedVersion,
+    port
+  })
+  const bot = mineflayer.createBot({
+    username: 'player',
+    version: supportedVersion,
+    port
+  })
+  bot.test = {}
+  bot.test.generateLoginPacket = () => {
+    const loginPacket = registry.loginPacket
+    loginPacket.entityId = 0
+    return loginPacket
+  }
+  return { server, bot }
+}
+
+function teardownBotTest (bot, server, done) {
+  let finished = false
+  const finish = () => {
+    if (finished) return
+    finished = true
+    done()
+  }
+  setTimeout(finish, 3000)
+  if (bot && !bot._client.ended) {
+    bot.once('end', () => server.close(() => finish()))
+    try {
+      bot.quit('test teardown')
+    } catch {
+      server.close(() => finish())
+    }
+    return
+  }
+  if (server) server.close(() => finish())
+  else finish()
+}
+
+describe('mineflayer_entity_physics horses 1.17.1v', function () {
+  this.timeout(10 * 1000)
+
+  const supportedVersion = '1.17.1'
+  let bot
+  let server
+
+  beforeEach((done) => {
+    ({ server, bot } = setupBotTest(supportedVersion, 25571))
+    server.once('listening', () => done())
+  })
+
+  afterEach((done) => {
+    teardownBotTest(bot, server, done)
+  })
+
+  for (const name of ['horse', 'donkey', 'mule', 'skeleton_horse', 'zombie_horse']) {
+    it(`does not create entity_physics context for remote ${name}`, (done) => {
+      server.on('playerJoin', (client) => {
+        withLogin(bot, client, done, async () => {
+          stubLoadedWorld(bot, 63)
+          const entity = makeRegistryEntity(bot, 100, name, vec3(0, 64, 0), vec3(0, -0.5, 0))
+          bot.entities[entity.id] = entity
+          const ctx = bot.entityPhysics.syncEntity(entity)
+          assert.strictEqual(ctx, null)
+          assert.strictEqual(bot.entityPhysics.contexts.has(entity.id), false)
+        })
+      })
+    })
+
+    it(`entityPhysicsTick does not move remote ${name}`, (done) => {
+      server.on('playerJoin', (client) => {
+        withLogin(bot, client, done, async () => {
+          stubLoadedWorld(bot, 63)
+          const entity = makeRegistryEntity(bot, 101, name, vec3(0, 64, 0), vec3(0, -0.5, 0))
+          bot.entities[entity.id] = entity
+          bot.entityPhysics.syncEntity(entity)
+          const beforeY = entity.position.y
+          bot.emit('entityPhysicsTick')
+          assert.strictEqual(entity.position.y, beforeY)
+        })
+      })
+    })
+  }
+
+  it('still simulates remote pig on 1.17.1', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot, 63)
+        const entity = makeRegistryEntity(bot, 200, 'pig', vec3(0, 64, 0), vec3(0, -0.5, 0))
+        bot.entities[entity.id] = entity
+        const ctx = bot.entityPhysics.syncEntity(entity)
+        assert(ctx)
+        assert(bot.entityPhysics.contexts.has(entity.id))
+        const beforeY = entity.position.y
+        bot.entityPhysics.simulateEntity(entity)
+        assert.notStrictEqual(entity.position.y, beforeY)
+      })
+    })
+  })
+})
+
+describe('mineflayer_entity_physics horses other versions', function () {
+  this.timeout(10 * 1000)
+
+  const supportedVersion = '1.18.2'
+  let bot
+  let server
+
+  beforeEach((done) => {
+    ({ server, bot } = setupBotTest(supportedVersion, 25572))
+    server.once('listening', () => done())
+  })
+
+  afterEach((done) => {
+    teardownBotTest(bot, server, done)
+  })
+
+  it('still simulates horse on 1.18.2', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot, 63)
+        const entity = makeRegistryEntity(bot, 300, 'horse', vec3(0, 64, 0), vec3(0, -0.5, 0))
+        bot.entities[entity.id] = entity
+        const ctx = bot.entityPhysics.syncEntity(entity)
+        assert(ctx)
+        const beforeY = entity.position.y
+        bot.entityPhysics.simulateEntity(entity)
+        assert.notStrictEqual(entity.position.y, beforeY)
+      })
+    })
+  })
+})
+
+describe('entity_physics horse name helper', () => {
+  it('recognizes all rideable horse variants', () => {
+    for (const name of ['horse', 'donkey', 'mule', 'skeleton_horse', 'zombie_horse']) {
+      assert.strictEqual(isRideableHorseEntityName(name), true)
+    }
+    assert.strictEqual(isRideableHorseEntityName('pig'), false)
+  })
+})

--- a/test/entityPhysicsVehicleTest.js
+++ b/test/entityPhysicsVehicleTest.js
@@ -1,0 +1,206 @@
+/* eslint-env mocha */
+
+const mineflayer = require('../')
+const mc = require('minecraft-protocol')
+const vec3 = require('vec3')
+const assert = require('assert')
+const { once } = require('../lib/promise_utils')
+
+function createBlockWorldStub (version, groundY = 63) {
+  const mcData = require('minecraft-data')(version)
+  const Block = require('prismarine-block')(version)
+  const stoneId = mcData.blocksByName.stone.id
+  const airId = mcData.blocksByName.air.id
+  const cache = new Map()
+
+  return (pos) => {
+    const blockPos = pos.floored()
+    const key = `${blockPos.x},${blockPos.y},${blockPos.z}`
+    const cached = cache.get(key)
+    if (cached) return cached
+
+    const type = blockPos.y < groundY ? stoneId : airId
+    const block = new Block(type, 0, 0)
+    block.position = blockPos
+    cache.set(key, block)
+    return block
+  }
+}
+
+function stubLoadedWorld (bot, groundY = 63) {
+  bot.blockAt = createBlockWorldStub(bot.version, groundY)
+}
+
+function loginBot (bot, client) {
+  client.write('login', bot.test.generateLoginPacket())
+  client.write('position', {
+    x: 0,
+    y: 64,
+    z: 0,
+    yaw: 0,
+    pitch: 0,
+    flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+    teleportId: 1
+  })
+}
+
+function makeRegistryEntity (bot, id, name, position, velocity, dimensions = {}) {
+  const entityTypeData = bot.registry.entitiesByName[name]
+  assert(entityTypeData, `expected registry entity for ${name}`)
+  return {
+    id,
+    name,
+    type: entityTypeData.type,
+    entityType: entityTypeData.id,
+    position: position.clone(),
+    velocity: velocity.clone(),
+    height: dimensions.height ?? (name === 'pig' ? 0.9 : 1.6),
+    width: dimensions.width ?? (name === 'pig' ? 0.9 : 1.3964844),
+    metadata: new Array(20).fill(0),
+    effects: [],
+    equipment: [],
+    isValid: true,
+    passengers: []
+  }
+}
+
+function withLogin (bot, client, done, runTest) {
+  bot.once('login', async () => {
+    try {
+      await once(bot, 'forcedMove')
+      await runTest()
+      done()
+    } catch (err) {
+      done(err)
+    }
+  })
+  loginBot(bot, client)
+}
+
+function setupBotTest (supportedVersion, port) {
+  const registry = require('prismarine-registry')(supportedVersion)
+  const server = mc.createServer({
+    'online-mode': false,
+    version: supportedVersion,
+    port
+  })
+  const bot = mineflayer.createBot({
+    username: 'player',
+    version: supportedVersion,
+    port
+  })
+  bot.test = {}
+  bot.test.generateLoginPacket = () => {
+    const loginPacket = registry.loginPacket
+    loginPacket.entityId = 0
+    return loginPacket
+  }
+  return { server, bot }
+}
+
+function teardownBotTest (bot, server, done) {
+  let finished = false
+  const finish = () => {
+    if (finished) return
+    finished = true
+    done()
+  }
+  setTimeout(finish, 3000)
+  if (bot && !bot._client.ended) {
+    bot.once('end', () => server.close(() => finish()))
+    try {
+      bot.quit('test teardown')
+    } catch {
+      server.close(() => finish())
+    }
+    return
+  }
+  if (server) server.close(() => finish())
+  else finish()
+}
+
+async function assertMountedVehicleExcludedFromGenericPhysics (bot, vehicle, neighbor) {
+  const vehicleYBefore = vehicle.position.y
+  const neighborYBefore = neighbor.position.y
+
+  assert(bot.entityPhysics.syncEntity(vehicle), 'expected generic context before mount')
+  assert(bot.entityPhysics.syncEntity(neighbor), 'expected generic context for neighbor')
+  assert(bot.entityPhysics.contexts.has(vehicle.id))
+  assert(bot.entityPhysics.contexts.has(neighbor.id))
+
+  bot._client.emit('set_passengers', { entityId: vehicle.id, passengers: [bot.entity.id] })
+  assert.strictEqual(bot.vehicle, vehicle)
+
+  await once(bot, 'physicsTickBegin')
+
+  assert.strictEqual(bot.entityPhysics.contexts.has(vehicle.id), false, 'mounted vehicle context must be removed')
+  assert.strictEqual(vehicle.position.y, vehicleYBefore, 'generic physics must not move mounted vehicle')
+  assert(bot.entityPhysics.contexts.has(neighbor.id), 'neighbor context must remain')
+  assert.notStrictEqual(neighbor.position.y, neighborYBefore, 'neighbor must keep simulating')
+}
+
+describe('mineflayer_entity_physics mounted vehicles', function () {
+  this.timeout(10 * 1000)
+
+  describe('1.18.2 legacy boat', function () {
+    let bot
+    let server
+
+    beforeEach((done) => {
+      ({ server, bot } = setupBotTest('1.18.2', 25573))
+      server.once('listening', () => done())
+    })
+
+    afterEach((done) => {
+      teardownBotTest(bot, server, done)
+    })
+
+    it('drops generic context and skips simulation after mount', (done) => {
+      server.on('playerJoin', (client) => {
+        withLogin(bot, client, done, async () => {
+          stubLoadedWorld(bot)
+          const boat = makeRegistryEntity(
+            bot, 100, 'boat', vec3(0, 63, 0), vec3(0, -0.5, 0),
+            { height: 0.5625, width: 1.375 }
+          )
+          const neighbor = makeRegistryEntity(bot, 200, 'pig', vec3(5, 64, 0), vec3(0, -0.5, 0))
+          bot.entities[boat.id] = boat
+          bot.entities[neighbor.id] = neighbor
+
+          await assertMountedVehicleExcludedFromGenericPhysics(bot, boat, neighbor)
+        })
+      })
+    })
+  })
+
+  describe('1.17.1 minecart', function () {
+    let bot
+    let server
+
+    beforeEach((done) => {
+      ({ server, bot } = setupBotTest('1.17.1', 25574))
+      server.once('listening', () => done())
+    })
+
+    afterEach((done) => {
+      teardownBotTest(bot, server, done)
+    })
+
+    it('drops generic context and skips simulation after mount', (done) => {
+      server.on('playerJoin', (client) => {
+        withLogin(bot, client, done, async () => {
+          stubLoadedWorld(bot)
+          const minecart = makeRegistryEntity(
+            bot, 100, 'minecart', vec3(0, 64, 0), vec3(0, -0.5, 0),
+            { height: 0.7, width: 0.98 }
+          )
+          const neighbor = makeRegistryEntity(bot, 200, 'pig', vec3(5, 64, 0), vec3(0, -0.5, 0))
+          bot.entities[minecart.id] = minecart
+          bot.entities[neighbor.id] = neighbor
+
+          await assertMountedVehicleExcludedFromGenericPhysics(bot, minecart, neighbor)
+        })
+      })
+    })
+  })
+})

--- a/test/horseLifecycleTest.js
+++ b/test/horseLifecycleTest.js
@@ -45,8 +45,14 @@ function loginBot (bot, client) {
 }
 
 function withLogin (bot, client, done, runTest) {
-  bot.once('login', () => {
-    runTest().then(() => done(), done)
+  bot.once('login', async () => {
+    try {
+      await once(bot, 'forcedMove')
+      await runTest()
+      done()
+    } catch (err) {
+      done(err)
+    }
   })
   loginBot(bot, client)
 }

--- a/test/horseLifecycleTest.js
+++ b/test/horseLifecycleTest.js
@@ -1,0 +1,175 @@
+/* eslint-env mocha */
+
+const mineflayer = require('../')
+const mc = require('minecraft-protocol')
+const vec3 = require('vec3')
+const assert = require('assert')
+const { once } = require('../lib/promise_utils')
+
+function createBlockWorldStub (version, groundY = 63) {
+  const mcData = require('minecraft-data')(version)
+  const Block = require('prismarine-block')(version)
+  const stoneId = mcData.blocksByName.stone.id
+  const airId = mcData.blocksByName.air.id
+  const cache = new Map()
+
+  return (pos) => {
+    const blockPos = pos.floored()
+    const key = `${blockPos.x},${blockPos.y},${blockPos.z}`
+    const cached = cache.get(key)
+    if (cached) return cached
+
+    const type = blockPos.y < groundY ? stoneId : airId
+    const block = new Block(type, 0, 0)
+    block.position = blockPos
+    cache.set(key, block)
+    return block
+  }
+}
+
+function stubLoadedWorld (bot, groundY = 63) {
+  bot.blockAt = createBlockWorldStub(bot.version, groundY)
+}
+
+function loginBot (bot, client) {
+  client.write('login', bot.test.generateLoginPacket())
+  client.write('position', {
+    x: 0,
+    y: 64,
+    z: 0,
+    yaw: 0,
+    pitch: 0,
+    flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+    teleportId: 1
+  })
+}
+
+function withLogin (bot, client, done, runTest) {
+  bot.once('login', () => {
+    runTest().then(() => done(), done)
+  })
+  loginBot(bot, client)
+}
+
+function setupHorse (bot, vehicleId) {
+  const horse = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
+  horse.name = 'horse'
+  horse.position = vec3(0, 64, 0)
+  horse.width = 1.3964844
+  horse.height = 1.6
+  horse.velocity = vec3(0, 0, 0)
+  horse.yaw = 0
+  horse.pitch = 0
+  horse.metadata = new Array(18).fill(0)
+  horse.metadata[17] = 0x04
+  horse.effects = []
+  horse.equipment = []
+  horse.attributes = {
+    'generic.movement_speed': { value: 0.225, modifiers: [] },
+    'horse.jump_strength': { value: 0.7, modifiers: [] }
+  }
+  bot.entities[vehicleId] = horse
+  bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+  return horse
+}
+
+describe('mineflayer_horse_lifecycle 1.17.1v', function () {
+  this.timeout(10 * 1000)
+
+  const supportedVersion = '1.17.1'
+  const registry = require('prismarine-registry')(supportedVersion)
+  let bot
+  let server
+
+  beforeEach((done) => {
+    server = mc.createServer({
+      'online-mode': false,
+      version: supportedVersion,
+      port: 25571
+    })
+    server.on('listening', () => {
+      bot = mineflayer.createBot({
+        username: 'player',
+        version: supportedVersion,
+        port: 25571
+      })
+      bot.test = {}
+      bot.test.generateLoginPacket = () => {
+        const loginPacket = registry.loginPacket
+        loginPacket.entityId = 0
+        return loginPacket
+      }
+      done()
+    })
+  })
+
+  afterEach((done) => {
+    let finished = false
+    const finish = () => {
+      if (finished) return
+      finished = true
+      done()
+    }
+    setTimeout(finish, 3000)
+    if (bot && !bot._client.ended) {
+      bot.once('end', () => server.close(() => finish()))
+      try {
+        bot.quit('test teardown')
+      } catch {
+        server.close(() => finish())
+      }
+      return
+    }
+    if (server) server.close(() => finish())
+    else finish()
+  })
+
+  it('clears mount state when vehicle entity is removed', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        setupHorse(bot, 100)
+        assert(bot.vehicle)
+        bot._client.emit('entity_destroy', { entityIds: [100] })
+        assert.strictEqual(bot.vehicle, null)
+        assert.ok(bot.entity.vehicle == null)
+      })
+    })
+  })
+
+  it('handles forced dismount from position packet', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        setupHorse(bot, 100)
+        let dismounted = false
+        bot.once('dismount', () => { dismounted = true })
+        bot._client.emit('position', {
+          x: 1,
+          y: 64,
+          z: 1,
+          yaw: 0,
+          pitch: 0,
+          flags: bot.supportFeature('positionPacketHasBitflags')
+            ? { x: false, y: false, z: false, yaw: false, pitch: false }
+            : 0,
+          teleportId: 2,
+          dismountVehicle: true
+        })
+        assert.strictEqual(bot.vehicle, null)
+        assert(dismounted)
+      })
+    })
+  })
+
+  it('destroys horse context on dismount', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupHorse(bot, 100)
+        await once(bot, 'physicsTick')
+        assert(bot._horsePhysics.getCtx())
+        bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+        assert.strictEqual(bot._horsePhysics.getCtx(), null)
+      })
+    })
+  })
+})

--- a/test/horsePhysicsTest.js
+++ b/test/horsePhysicsTest.js
@@ -304,6 +304,36 @@ describe('mineflayer_horse_physics 1.17.1v', function () {
     })
   })
 
+  it('ignores entity_head_rotation for controlled horse', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const horse = setupHorse(bot, 100, vec3(0, 64, 0))
+        await once(bot, 'physicsTick')
+        horse.headYaw = horse.yaw
+        bot._client.emit('entity_head_rotation', { entityId: 100, headYaw: 64 })
+        assert.strictEqual(horse.headYaw, horse.yaw)
+      })
+    })
+  })
+
+  it('updates headYaw for remote horse entity_head_rotation', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        const entityId = 300
+        const horse = bot.entities[entityId] ?? { id: entityId, passengers: [] }
+        horse.name = 'horse'
+        horse.position = vec3(5, 64, 5)
+        horse.yaw = 0
+        horse.headYaw = 0
+        bot.entities[entityId] = horse
+
+        bot._client.emit('entity_head_rotation', { entityId, headYaw: 64 })
+        assert.strictEqual(horse.headYaw, conv.fromNotchianYawByte(64))
+      })
+    })
+  })
+
   it('anchors player seat at vanilla horse feet offset', (done) => {
     server.on('playerJoin', (client) => {
       withLogin(bot, client, done, async () => {

--- a/test/horsePhysicsTest.js
+++ b/test/horsePhysicsTest.js
@@ -1,0 +1,301 @@
+/* eslint-env mocha */
+
+const mineflayer = require('../')
+const mc = require('minecraft-protocol')
+const vec3 = require('vec3')
+const assert = require('assert')
+const conv = require('../lib/conversions')
+const { once } = require('../lib/promise_utils')
+
+function createBlockWorldStub (version, groundY = 63) {
+  const mcData = require('minecraft-data')(version)
+  const Block = require('prismarine-block')(version)
+  const stoneId = mcData.blocksByName.stone.id
+  const airId = mcData.blocksByName.air.id
+  const cache = new Map()
+
+  return (pos) => {
+    const blockPos = pos.floored()
+    const key = `${blockPos.x},${blockPos.y},${blockPos.z}`
+    const cached = cache.get(key)
+    if (cached) return cached
+
+    const type = blockPos.y < groundY ? stoneId : airId
+    const block = new Block(type, 0, 0)
+    block.position = blockPos
+    cache.set(key, block)
+    return block
+  }
+}
+
+function stubLoadedWorld (bot, groundY = 63) {
+  bot.blockAt = createBlockWorldStub(bot.version, groundY)
+}
+
+function captureWrites (bot) {
+  const writes = []
+  const oldWrite = bot._client.write
+  bot._client.write = function (name, data) {
+    writes.push({ name, data })
+    return oldWrite.apply(bot._client, arguments)
+  }
+  return writes
+}
+
+function loginBot (bot, client) {
+  client.write('login', bot.test.generateLoginPacket())
+  client.write('position', {
+    x: 0,
+    y: 64,
+    z: 0,
+    yaw: 0,
+    pitch: 0,
+    flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+    teleportId: 1
+  })
+}
+
+function setupHorse (bot, vehicleId, position, options = {}) {
+  const horse = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
+  horse.name = options.name ?? 'horse'
+  horse.position = position.clone ? position.clone() : vec3(position.x, position.y, position.z)
+  horse.width = options.width ?? 1.3964844
+  horse.height = options.height ?? 1.6
+  horse.velocity = vec3(0, 0, 0)
+  horse.yaw = 0
+  horse.pitch = 0
+  horse.metadata = options.metadata ?? new Array(18).fill(0)
+  horse.metadata[17] = options.saddled === false ? 0 : 0x04
+  horse.attributes = options.attributes ?? {
+    'generic.movement_speed': { value: 0.225, modifiers: [] },
+    'horse.jump_strength': { value: 0.7, modifiers: [] }
+  }
+  horse.effects ??= []
+  horse.equipment ??= []
+  bot.entities[vehicleId] = horse
+  bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+  return horse
+}
+
+function withLogin (bot, client, done, runTest) {
+  bot.once('login', async () => {
+    try {
+      await once(bot, 'forcedMove')
+      await runTest()
+      done()
+    } catch (err) {
+      done(err)
+    }
+  })
+  loginBot(bot, client)
+}
+
+describe('mineflayer_horse_physics 1.17.1v', function () {
+  this.timeout(10 * 1000)
+
+  const supportedVersion = '1.17.1'
+  const registry = require('prismarine-registry')(supportedVersion)
+  let bot
+  let server
+
+  beforeEach((done) => {
+    server = mc.createServer({
+      'online-mode': false,
+      version: supportedVersion,
+      port: 25570
+    })
+    server.on('listening', () => {
+      bot = mineflayer.createBot({
+        username: 'player',
+        version: supportedVersion,
+        port: 25570
+      })
+      bot.test = {}
+      bot.test.generateLoginPacket = () => {
+        const loginPacket = registry.loginPacket
+        loginPacket.entityId = 0
+        return loginPacket
+      }
+      done()
+    })
+  })
+
+  afterEach((done) => {
+    let finished = false
+    const finish = () => {
+      if (finished) return
+      finished = true
+      done()
+    }
+    setTimeout(finish, 3000)
+    if (bot && !bot._client.ended) {
+      bot.once('end', () => server.close(() => finish()))
+      try {
+        bot.quit('test teardown')
+      } catch {
+        server.close(() => finish())
+      }
+      return
+    }
+    if (server) server.close(() => finish())
+    else finish()
+  })
+
+  it('creates horse context for saddled first passenger', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupHorse(bot, 100, vec3(0, 64, 0))
+        await once(bot, 'physicsTick')
+        assert(bot._horsePhysics.getCtx())
+        assert.strictEqual(bot._horsePhysics.getCtx().state.constructor.name, 'HorseState')
+      })
+    })
+  })
+
+  it('does not control horse without saddle', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupHorse(bot, 100, vec3(0, 64, 0), { saddled: false })
+        assert.strictEqual(bot._horsePhysics.getCtx(), null)
+      })
+    })
+  })
+
+  it('does not control horse as second passenger', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const horse = setupHorse(bot, 100, vec3(0, 64, 0))
+        bot._client.emit('set_passengers', { entityId: 100, passengers: [200, bot.entity.id] })
+        await once(bot, 'physicsTick')
+        assert.strictEqual(bot.vehicle?.id, 100)
+        assert.strictEqual(bot._horsePhysics.getCtx(), null)
+        assert.strictEqual(horse.position.z, 0)
+      })
+    })
+  })
+
+  it('sends look, steer_vehicle, and vehicle_move with notchian degrees', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupHorse(bot, 100, vec3(0, 64, 0))
+        bot.entity.yaw = Math.PI / 4
+        const writes = captureWrites(bot)
+        bot.setControlState('forward', true)
+        await once(bot, 'physicsTick')
+        bot.setControlState('forward', false)
+
+        const names = writes.map(w => w.name)
+        const lookIdx = names.indexOf('look')
+        const steerIdx = names.indexOf('steer_vehicle')
+        const moveIdx = names.lastIndexOf('vehicle_move')
+        assert.ok(lookIdx >= 0)
+        assert.ok(steerIdx > lookIdx)
+        assert.ok(moveIdx > steerIdx)
+        const packet = writes[moveIdx]
+        assert(packet, 'expected vehicle_move')
+        assert.ok(Math.abs(conv.toNotchianYaw(bot.vehicle.yaw)) > 10, 'horse yaw should follow rider look')
+        assert.ok(Math.abs(packet.data.yaw) > 10)
+        assert.ok(Math.abs(packet.data.pitch) <= 90)
+      })
+    })
+  })
+
+  it('uses left-positive sideways in steer_vehicle', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupHorse(bot, 100, vec3(0, 64, 0))
+        bot.setControlState('left', true)
+        const writes = captureWrites(bot)
+        await once(bot, 'physicsTick')
+        const steer = writes.find(w => w.name === 'steer_vehicle')
+        assert(steer)
+        assert.ok(steer.data.sideways > 0)
+      })
+    })
+  })
+
+  it('sends START_RIDING_JUMP on jump release', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupHorse(bot, 100, vec3(0, 64, 0))
+        bot.setControlState('jump', true)
+        await once(bot, 'physicsTick')
+        const writes = captureWrites(bot)
+        bot.setControlState('jump', false)
+        await once(bot, 'physicsTick')
+        const action = writes.find(w => w.name === 'entity_action' && w.data.actionId === 5)
+        assert(action, 'expected START_RIDING_JUMP')
+        assert.ok(Number.isInteger(action.data.jumpBoost))
+        assert.ok(action.data.jumpBoost >= 0 && action.data.jumpBoost <= 100)
+        assert.strictEqual(writes.some(w => w.name === 'entity_action' && w.data.actionId === 6), false)
+        const names = writes.map(w => w.name)
+        const lookIdx = names.indexOf('look')
+        const actionIdx = writes.indexOf(action)
+        const steerIdx = names.indexOf('steer_vehicle')
+        const moveIdx = names.indexOf('vehicle_move')
+        assert.ok(lookIdx >= 0)
+        assert.ok(actionIdx > lookIdx)
+        assert.ok(steerIdx > actionIdx)
+        assert.ok(moveIdx > steerIdx)
+      })
+    })
+  })
+
+  it('rebases on vehicle_move correction and echoes packet', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const horse = setupHorse(bot, 100, vec3(0, 64, 0))
+        await once(bot, 'physicsTick')
+        const writes = captureWrites(bot)
+        bot._client.emit('vehicle_move', { x: 2, y: 64, z: 3, yaw: 45, pitch: 10 })
+        const echo = writes.find(w => w.name === 'vehicle_move')
+        assert(echo)
+        assert.strictEqual(echo.data.x, 2)
+        assert.strictEqual(horse.position.x, 2)
+      })
+    })
+  })
+
+  it('accepts entity_velocity as knockback correction', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const horse = setupHorse(bot, 100, vec3(0, 64, 0))
+        await once(bot, 'physicsTick')
+        bot._client.emit('entity_velocity', { entityId: 100, velocityX: 1000, velocityY: 500, velocityZ: -1000 })
+        assert.notStrictEqual(horse.velocity.x, 0)
+      })
+    })
+  })
+
+  it('ignores rel_entity_move for controlled horse', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const horse = setupHorse(bot, 100, vec3(0, 64, 0))
+        await once(bot, 'physicsTick')
+        const before = horse.position.clone()
+        bot._client.emit('rel_entity_move', { entityId: 100, dX: 320, dY: 0, dZ: 0 })
+        assert.strictEqual(horse.position.x, before.x)
+      })
+    })
+  })
+
+  it('anchors player seat at vanilla horse feet offset', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const horse = setupHorse(bot, 100, vec3(1, 64, 2))
+        await once(bot, 'physicsTick')
+        assert.ok(Math.abs(bot.entity.position.y - (horse.position.y + 0.85)) < 0.01)
+      })
+    })
+  })
+})

--- a/test/horsePhysicsTest.js
+++ b/test/horsePhysicsTest.js
@@ -153,11 +153,27 @@ describe('mineflayer_horse_physics 1.17.1v', function () {
     })
   })
 
+  it('emits entityPhysicsTick for controlled horse', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupHorse(bot, 100, vec3(0, 64, 0))
+
+        let entityPhysicsTicks = 0
+        bot.on('entityPhysicsTick', () => { entityPhysicsTicks++ })
+        await once(bot, 'physicsTick')
+
+        assert.ok(entityPhysicsTicks >= 1, 'expected entityPhysicsTick while controlling horse')
+      })
+    })
+  })
+
   it('does not control horse without saddle', (done) => {
     server.on('playerJoin', (client) => {
       withLogin(bot, client, done, async () => {
         stubLoadedWorld(bot)
         setupHorse(bot, 100, vec3(0, 64, 0), { saddled: false })
+        await once(bot, 'physicsTickBegin')
         assert.strictEqual(bot._horsePhysics.getCtx(), null)
       })
     })

--- a/test/horsePhysicsTest.js
+++ b/test/horsePhysicsTest.js
@@ -314,4 +314,110 @@ describe('mineflayer_horse_physics 1.17.1v', function () {
       })
     })
   })
+
+  it('snaps unsaddled horse passenger on mount and emits one move', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        bot.entity.position.set(5, 72, 8)
+        bot.entity.velocity.set(0.1, 0.2, 0.3)
+        let moveCount = 0
+        let moveOldPos = null
+        bot.on('move', (oldPos) => {
+          moveCount++
+          moveOldPos = oldPos.clone()
+        })
+        const horse = setupHorse(bot, 100, vec3(1, 64, 2), { saddled: false })
+        assert.strictEqual(bot._horsePhysics.getCtx(), null)
+        assert.ok(Math.abs(bot.entity.position.x - horse.position.x) < 0.01)
+        assert.ok(Math.abs(bot.entity.position.z - horse.position.z) < 0.01)
+        assert.ok(Math.abs(bot.entity.position.y - (horse.position.y + 0.85)) < 0.01)
+        assert.strictEqual(bot.entity.velocity.x, horse.velocity.x)
+        assert.strictEqual(bot.entity.velocity.y, horse.velocity.y)
+        assert.strictEqual(bot.entity.velocity.z, horse.velocity.z)
+        assert.strictEqual(moveCount, 1)
+        assert.strictEqual(moveOldPos.y, 72)
+        await once(bot, 'physicsTickBegin')
+        assert.ok(Math.abs(bot.entity.position.y - (horse.position.y + 0.85)) < 0.01)
+      })
+    })
+  })
+
+  it('unsaddled horse keeps vanilla feet offset after physics tick from mismatched mount Y', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        bot.entity.position.set(0, 68, 0)
+        const horse = setupHorse(bot, 100, vec3(0, 64, 0), { saddled: false })
+        await once(bot, 'physicsTickBegin')
+        assert.strictEqual(bot._horsePhysics.getCtx(), null)
+        assert.ok(Math.abs(bot.entity.position.y - (horse.position.y + 0.85)) < 0.01)
+      })
+    })
+  })
+})
+
+describe('mineflayer_horse_passenger_sync non-1.17.1', function () {
+  this.timeout(10 * 1000)
+
+  const supportedVersion = '1.20.4'
+  const registry = require('prismarine-registry')(supportedVersion)
+  let bot
+  let server
+
+  beforeEach((done) => {
+    server = mc.createServer({
+      'online-mode': false,
+      version: supportedVersion,
+      port: 25571
+    })
+    server.on('listening', () => {
+      bot = mineflayer.createBot({
+        username: 'player',
+        version: supportedVersion,
+        port: 25571
+      })
+      bot.test = {}
+      bot.test.generateLoginPacket = () => {
+        const loginPacket = registry.loginPacket
+        loginPacket.entityId = 0
+        return loginPacket
+      }
+      done()
+    })
+  })
+
+  afterEach((done) => {
+    let finished = false
+    const finish = () => {
+      if (finished) return
+      finished = true
+      done()
+    }
+    setTimeout(finish, 3000)
+    if (bot && !bot._client.ended) {
+      bot.once('end', () => server.close(() => finish()))
+      try {
+        bot.quit('test teardown')
+      } catch {
+        server.close(() => finish())
+      }
+      return
+    }
+    if (server) server.close(() => finish())
+    else finish()
+  })
+
+  it('keeps generic vehicle.height offset for unsaddled horse', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        bot.entity.position.set(0, 68, 0)
+        const horse = setupHorse(bot, 100, vec3(0, 64, 0), { saddled: false })
+        await once(bot, 'physicsTickBegin')
+        assert.ok(Math.abs(bot.entity.position.y - (horse.position.y + horse.height)) < 0.01)
+        assert.ok(Math.abs(bot.entity.position.y - (horse.position.y + 0.85)) > 0.5)
+      })
+    })
+  })
 })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -8,6 +8,7 @@ const { sleep } = require('../lib/promise_utils')
 const nbt = require('prismarine-nbt')
 const { once } = require('../lib/promise_utils')
 const { getPort } = require('./common/util')
+const conv = require('../lib/conversions')
 
 for (const supportedVersion of mineflayer.testedVersions) {
   const registry = require('prismarine-registry')(supportedVersion)
@@ -955,6 +956,11 @@ for (const supportedVersion of mineflayer.testedVersions) {
         server.on('playerJoin', (client) => {
           bot.on('entitySpawn', (entity) => {
             assert.strictEqual(entity.displayName, 'Creeper')
+            if (typeof entity.headYaw === 'number') {
+              assert.strictEqual(entity.pitch, conv.fromNotchianPitchByte(14))
+              assert.strictEqual(entity.headYaw, conv.fromNotchianYawByte(14))
+              assert.strictEqual(entity.headPitch, undefined)
+            }
 
             const lastMeta = entity.metadata
             bot.on('entityUpdate', (entity) => {

--- a/test/minecartLifecycleTest.js
+++ b/test/minecartLifecycleTest.js
@@ -1,0 +1,381 @@
+/* eslint-env mocha */
+
+const mineflayer = require('../')
+const mc = require('minecraft-protocol')
+const vec3 = require('vec3')
+const assert = require('assert')
+const { once } = require('../lib/promise_utils')
+
+const MINECART_VARIANTS = [
+  'minecart',
+  'chest_minecart',
+  'furnace_minecart',
+  'hopper_minecart',
+  'tnt_minecart',
+  'spawner_minecart',
+  'command_block_minecart'
+]
+
+function captureWrites (bot) {
+  const writes = []
+  const oldWrite = bot._client.write
+  bot._client.write = function (name, data) {
+    writes.push({ name, data })
+    return oldWrite.apply(bot._client, arguments)
+  }
+  return writes
+}
+
+function loginBot (bot, client, registry) {
+  client.write('login', (() => {
+    const loginPacket = registry.loginPacket
+    loginPacket.entityId = 0
+    return loginPacket
+  })())
+  client.write('position', {
+    x: 0,
+    y: 64,
+    z: 0,
+    yaw: 0,
+    pitch: 0,
+    flags: { x: false, y: false, z: false, yaw: false, pitch: false },
+    teleportId: 1
+  })
+}
+
+function setupMinecart (bot, vehicleId, name, position) {
+  const minecart = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
+  minecart.name = name
+  minecart.position = position.clone ? position.clone() : vec3(position.x, position.y, position.z)
+  minecart.width = 0.98
+  minecart.height = 0.7
+  minecart.velocity = vec3(0, 0, 0)
+  minecart.yaw = 0
+  minecart.pitch = 0
+  minecart.metadata ??= []
+  minecart.effects ??= []
+  minecart.equipment ??= []
+  bot.entities[vehicleId] = minecart
+  bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+  return minecart
+}
+
+function stubLoadedWorld (bot) {
+  const Block = require('prismarine-block')(bot.version)
+  const air = Block.fromStateId(0, 0)
+  bot.blockAt = () => air
+}
+
+async function completeLoginHandshake (bot) {
+  await once(bot, 'forcedMove')
+  await once(bot, 'physicsTick')
+}
+
+describe('mineflayer_minecart_lifecycle 1.17.1v', function () {
+  this.timeout(10 * 1000)
+
+  const supportedVersion = '1.17.1'
+  const registry = require('prismarine-registry')(supportedVersion)
+  let bot
+  let server
+
+  beforeEach((done) => {
+    server = mc.createServer({
+      'online-mode': false,
+      version: supportedVersion,
+      port: 25571
+    })
+    server.on('listening', () => {
+      bot = mineflayer.createBot({
+        username: 'player',
+        version: supportedVersion,
+        port: 25571
+      })
+      done()
+    })
+  })
+
+  afterEach((done) => {
+    bot.on('end', () => done())
+    server.close()
+  })
+
+  it('syncs player position on entityMoved before the next physics tick', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', async () => {
+        stubLoadedWorld(bot)
+        await completeLoginHandshake(bot)
+
+        const minecart = setupMinecart(bot, 100, 'minecart', vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+
+        const writes = captureWrites(bot)
+        let moveCount = 0
+        bot.on('move', () => { moveCount++ })
+
+        bot._client.emit('rel_entity_move', {
+          entityId: 100,
+          dX: 4096,
+          dY: 0,
+          dZ: 0
+        })
+
+        assert.ok(Math.abs(minecart.position.x - 1) < 0.01)
+        assert.ok(Math.abs(bot.entity.position.x - 1) < 0.01, 'player X should sync on entityMoved')
+        assert.ok(Math.abs(bot.entity.position.y - 63.7) < 0.01, 'player Y should sync on entityMoved')
+        assert.ok(moveCount >= 1, 'expected move event before next physics tick')
+
+        const positionAfterEntityMoved = bot.entity.position.clone()
+        await once(bot, 'physicsTick')
+        assert.ok(positionAfterEntityMoved.equals(bot.entity.position), 'physics tick must not revert synced position')
+
+        const movesBeforeLook = moveCount
+        bot._client.emit('entity_look', { entityId: 100, yaw: 64, pitch: 0 })
+        assert.strictEqual(moveCount, movesBeforeLook, 'entity_look without movement must not emit move')
+
+        assert.strictEqual(writes.filter(w => w.name === 'vehicle_move').length, 0)
+        done()
+      })
+      loginBot(bot, client, registry)
+    })
+  })
+
+  it('keeps physics tick active after mount and follows server minecart movement', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', async () => {
+        stubLoadedWorld(bot)
+        await completeLoginHandshake(bot)
+
+        const mountPosition = vec3(0, 63, 0)
+        const minecart = setupMinecart(bot, 100, 'minecart', mountPosition)
+        bot.entity.position.set(0, 64, 0)
+
+        const writes = captureWrites(bot)
+        let moveEvents = 0
+        bot.on('move', () => { moveEvents++ })
+
+        await once(bot, 'physicsTick')
+
+        bot._client.emit('rel_entity_move', {
+          entityId: 100,
+          dX: 4096,
+          dY: 0,
+          dZ: 4096
+        })
+        assert.ok(Math.abs(minecart.position.x - 1) < 0.01)
+        assert.ok(Math.abs(minecart.position.z - 1) < 0.01)
+
+        await once(bot, 'physicsTick')
+
+        assert.ok(Math.abs(bot.entity.position.x - 1) < 0.01, 'player X should follow minecart')
+        assert.ok(Math.abs(bot.entity.position.y - 63.7) < 0.01, 'player Y should follow minecart')
+        assert.ok(Math.abs(bot.entity.position.z - 1) < 0.01, 'player Z should follow minecart')
+        assert.ok(moveEvents > 0, 'expected move events while riding minecart')
+        assert.strictEqual(writes.filter(w => w.name === 'vehicle_move').length, 0)
+        assert.ok(writes.some(w => w.name === 'steer_vehicle'), 'expected steer_vehicle packets')
+        done()
+      })
+      loginBot(bot, client, registry)
+    })
+  })
+
+  it('dismount after movement keeps player near minecart not original mount point', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', async () => {
+        stubLoadedWorld(bot)
+        await completeLoginHandshake(bot)
+
+        const originalMountPoint = vec3(0, 64, 0)
+        bot.entity.position.set(originalMountPoint.x, originalMountPoint.y, originalMountPoint.z)
+
+        const vehicleId = 100
+        const minecart = setupMinecart(bot, vehicleId, 'minecart', vec3(0, 63, 0))
+
+        await once(bot, 'physicsTick')
+
+        bot._client.emit('rel_entity_move', {
+          entityId: vehicleId,
+          dX: 8192,
+          dY: 0,
+          dZ: 4096
+        })
+        await once(bot, 'physicsTick')
+
+        const positionBeforeDismount = bot.entity.position.clone()
+        assert.ok(
+          Math.abs(positionBeforeDismount.x - 2) < 0.05 &&
+          Math.abs(positionBeforeDismount.z - 1) < 0.05,
+          'player should already be near moving minecart before dismount'
+        )
+        assert.ok(
+          (positionBeforeDismount.x - originalMountPoint.x) ** 2 +
+          (positionBeforeDismount.z - originalMountPoint.z) ** 2 > 0.5,
+          'player should have moved away from original mount point'
+        )
+
+        bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [] })
+        assert.strictEqual(bot.vehicle, null)
+
+        assert.ok(
+          Math.abs(bot.entity.position.x - positionBeforeDismount.x) < 0.01 &&
+          Math.abs(bot.entity.position.y - positionBeforeDismount.y) < 0.01 &&
+          Math.abs(bot.entity.position.z - positionBeforeDismount.z) < 0.01,
+          'dismount must not snap player back to original mount point'
+        )
+        assert.ok(
+          Math.abs(bot.entity.position.x - minecart.position.x) < 0.1 &&
+          Math.abs(bot.entity.position.z - minecart.position.z) < 0.1,
+          'player should remain near minecart after dismount'
+        )
+        done()
+      })
+      loginBot(bot, client, registry)
+    })
+  })
+
+  it('set_passengers mounts bot in minecart', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', () => {
+        const vehicleId = 100
+        let mountCount = 0
+        bot.on('mount', () => { mountCount++ })
+
+        setupMinecart(bot, vehicleId, 'minecart', vec3(0, 63, 0))
+
+        assert.strictEqual(bot.vehicle?.id, vehicleId)
+        assert.strictEqual(bot.entity.vehicle?.id, vehicleId)
+        assert.strictEqual(mountCount, 1)
+        done()
+      })
+      loginBot(bot, client, registry)
+    })
+  })
+
+  it('does not send vehicle_move during routine physics ticks', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', async () => {
+        stubLoadedWorld(bot)
+        setupMinecart(bot, 100, 'minecart', vec3(0, 63, 0))
+        const writes = captureWrites(bot)
+
+        for (let i = 0; i < 4; i++) {
+          await once(bot, 'physicsTick')
+        }
+
+        assert.strictEqual(writes.filter(w => w.name === 'vehicle_move').length, 0)
+        assert.ok(writes.some(w => w.name === 'steer_vehicle'), 'expected steer_vehicle packets')
+        done()
+      })
+      loginBot(bot, client, registry)
+    })
+  })
+
+  it('syncs bot.entity.position from minecart on physics tick', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', async () => {
+        stubLoadedWorld(bot)
+        const minecart = setupMinecart(bot, 100, 'minecart', vec3(1, 63, 2))
+        minecart.height = 0.7
+        bot.entity.position.set(0, 50, 0)
+
+        await once(bot, 'physicsTick')
+
+        assert.strictEqual(bot.entity.position.x, 1)
+        assert.strictEqual(bot.entity.position.y, 63.7)
+        assert.strictEqual(bot.entity.position.z, 2)
+        done()
+      })
+      loginBot(bot, client, registry)
+    })
+  })
+
+  it('rel_entity_move updates minecart position and syncs player on next physics tick', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', async () => {
+        stubLoadedWorld(bot)
+        const minecart = setupMinecart(bot, 100, 'minecart', vec3(0, 63, 0))
+
+        bot._client.emit('rel_entity_move', {
+          entityId: 100,
+          dX: 4096,
+          dY: 0,
+          dZ: 0
+        })
+        assert.ok(Math.abs(minecart.position.x - 1) < 0.01)
+
+        await once(bot, 'physicsTick')
+        assert.ok(Math.abs(bot.entity.position.x - 1) < 0.01)
+        done()
+      })
+      loginBot(bot, client, registry)
+    })
+  })
+
+  it('entity_move_look updates minecart position and rotation', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', async () => {
+        stubLoadedWorld(bot)
+        const minecart = setupMinecart(bot, 100, 'minecart', vec3(0, 63, 0))
+
+        bot._client.emit('entity_move_look', {
+          entityId: 100,
+          dX: 4096,
+          dY: 0,
+          dZ: 4096,
+          yaw: 64,
+          pitch: 0
+        })
+
+        assert.ok(Math.abs(minecart.position.x - 1) < 0.01)
+        assert.ok(Math.abs(minecart.position.z - 1) < 0.01)
+        assert.ok(Number.isFinite(minecart.yaw))
+
+        await once(bot, 'physicsTick')
+        assert.ok(Math.abs(bot.entity.position.x - 1) < 0.01)
+        assert.ok(Math.abs(bot.entity.position.z - 1) < 0.01)
+        done()
+      })
+      loginBot(bot, client, registry)
+    })
+  })
+
+  it('empty set_passengers completes mount lifecycle', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', () => {
+        const vehicleId = 100
+        let mountCount = 0
+        let dismountCount = 0
+        bot.on('mount', () => { mountCount++ })
+        bot.on('dismount', () => { dismountCount++ })
+
+        setupMinecart(bot, vehicleId, 'minecart', vec3(0, 63, 0))
+        assert.strictEqual(mountCount, 1)
+
+        bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [] })
+        assert.strictEqual(bot.vehicle, null)
+        assert.strictEqual(bot.entity.vehicle, undefined)
+        assert.strictEqual(mountCount, 1)
+        assert.strictEqual(dismountCount, 1)
+        done()
+      })
+      loginBot(bot, client, registry)
+    })
+  })
+
+  for (const variant of MINECART_VARIANTS) {
+    it(`classifies ${variant} as server-authoritative minecart`, (done) => {
+      server.on('playerJoin', (client) => {
+        bot.once('login', async () => {
+          stubLoadedWorld(bot)
+          setupMinecart(bot, 100, variant, vec3(0, 63, 0))
+          const writes = captureWrites(bot)
+          await once(bot, 'physicsTick')
+          assert.strictEqual(writes.filter(w => w.name === 'vehicle_move').length, 0)
+          assert.ok(writes.some(w => w.name === 'steer_vehicle'))
+          done()
+        })
+        loginBot(bot, client, registry)
+      })
+    })
+  }
+})

--- a/test/minecartLifecycleTest.js
+++ b/test/minecartLifecycleTest.js
@@ -122,7 +122,7 @@ describe('mineflayer_minecart_lifecycle 1.17.1v', function () {
 
         assert.ok(Math.abs(minecart.position.x - 1) < 0.01)
         assert.ok(Math.abs(bot.entity.position.x - 1) < 0.01, 'player X should sync on entityMoved')
-        assert.ok(Math.abs(bot.entity.position.y - 63.7) < 0.01, 'player Y should sync on entityMoved')
+        assert.ok(Math.abs(bot.entity.position.y - 62.65) < 0.01, 'player Y should sync on entityMoved')
         assert.ok(moveCount >= 1, 'expected move event before next physics tick')
 
         const positionAfterEntityMoved = bot.entity.position.clone()
@@ -168,7 +168,7 @@ describe('mineflayer_minecart_lifecycle 1.17.1v', function () {
         await once(bot, 'physicsTick')
 
         assert.ok(Math.abs(bot.entity.position.x - 1) < 0.01, 'player X should follow minecart')
-        assert.ok(Math.abs(bot.entity.position.y - 63.7) < 0.01, 'player Y should follow minecart')
+        assert.ok(Math.abs(bot.entity.position.y - 62.65) < 0.01, 'player Y should follow minecart')
         assert.ok(Math.abs(bot.entity.position.z - 1) < 0.01, 'player Z should follow minecart')
         assert.ok(moveEvents > 0, 'expected move events while riding minecart')
         assert.strictEqual(writes.filter(w => w.name === 'vehicle_move').length, 0)
@@ -238,13 +238,19 @@ describe('mineflayer_minecart_lifecycle 1.17.1v', function () {
       bot.once('login', () => {
         const vehicleId = 100
         let mountCount = 0
+        const oldPos = bot.entity.position.clone()
+        const moves = []
         bot.on('mount', () => { mountCount++ })
+        bot.on('move', previousPosition => moves.push(previousPosition))
 
-        setupMinecart(bot, vehicleId, 'minecart', vec3(0, 63, 0))
+        const minecart = setupMinecart(bot, vehicleId, 'minecart', vec3(0, 63, 0))
 
         assert.strictEqual(bot.vehicle?.id, vehicleId)
         assert.strictEqual(bot.entity.vehicle?.id, vehicleId)
         assert.strictEqual(mountCount, 1)
+        assert.strictEqual(bot.entity.position.y, minecart.position.y - 0.35)
+        assert.strictEqual(moves.length, 1)
+        assert(moves[0].equals(oldPos), 'move event must contain the pre-mount position')
         done()
       })
       loginBot(bot, client, registry)
@@ -281,7 +287,7 @@ describe('mineflayer_minecart_lifecycle 1.17.1v', function () {
         await once(bot, 'physicsTick')
 
         assert.strictEqual(bot.entity.position.x, 1)
-        assert.strictEqual(bot.entity.position.y, 63.7)
+        assert.strictEqual(bot.entity.position.y, 62.65)
         assert.strictEqual(bot.entity.position.z, 2)
         done()
       })

--- a/test/physicsCapabilityScenario.js
+++ b/test/physicsCapabilityScenario.js
@@ -105,7 +105,7 @@ function setupBoat (bot, vehicleId, position) {
   return boat
 }
 
-function setupHorse (bot, vehicleId, position) {
+function setupHorse (bot, vehicleId, position, options = {}) {
   const horse = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
   horse.name = 'horse'
   horse.position = position.clone ? position.clone() : vec3(position.x, position.y, position.z)
@@ -115,7 +115,7 @@ function setupHorse (bot, vehicleId, position) {
   horse.yaw = 0
   horse.pitch = 0
   horse.metadata = new Array(18).fill(0)
-  horse.metadata[17] = 0x04
+  horse.metadata[17] = options.saddled === false ? 0 : 0x04
   horse.attributes = {
     'generic.movement_speed': { value: 0.225, modifiers: [] },
     horse_jump_strength: { value: 0.7, modifiers: [] }
@@ -261,6 +261,16 @@ async function runBoatsOnlyScenario () {
       setupBoat(bot, 42, vec3(0, 63, 0))
       await tickPhysics(bot, 2)
       assert.ok(bot._boatPhysics.getCtx(), 'expected local boat context on supported version')
+
+      dismountVehicle(bot, 42)
+      bot.entity.position.set(0, 68, 0)
+      const horse = setupHorse(bot, 43, vec3(0, 63, 0), { saddled: false })
+      assert.strictEqual(bot._horsePhysics.getCtx(), null)
+      assert.ok(Math.abs(bot.entity.position.y - (horse.position.y + 0.85)) < 0.01,
+        'unsaddled horse passenger sync must work without horse exports')
+      await tickPhysics(bot, 1)
+      assert.ok(Math.abs(bot.entity.position.y - (horse.position.y + 0.85)) < 0.01,
+        'unsaddled horse passenger sync must persist across physics ticks')
     })
   })
 }

--- a/test/physicsCapabilityScenario.js
+++ b/test/physicsCapabilityScenario.js
@@ -5,9 +5,47 @@ const vec3 = require('vec3')
 const Module = require('module')
 const path = require('path')
 
-const scenario = process.argv[2]
+const scenarioArg = process.argv[2] || 'all'
+const scenarios = scenarioArg === 'all'
+  ? ['boats-only', 'no-transport', 'full-transport', 'warn-once']
+  : [scenarioArg]
 const supportedVersion = '1.17.1'
 const realUtil = require('@nxg-org/mineflayer-physics-util')
+
+function createStubHorseExports () {
+  class StubHorsePhysics {
+    constructor (registry) {
+      this.registry = registry
+      this.data = registry
+    }
+
+    simulate (ctx) {
+      ctx.state.worldReady = true
+    }
+  }
+
+  class StubHorseState {
+    constructor () {
+      this.worldReady = true
+      this.vel = { set () {} }
+    }
+
+    applyToEntity () {}
+    updateControls () {}
+    updateFromHorseEntity () {}
+    updateJumpCharge () { return null }
+    rebaseFromEntity () {}
+    clone () { return this }
+
+    static CREATE_FROM_ENTITY (horsePhysics, vehicle) {
+      const state = new StubHorseState()
+      state.vel = vehicle.velocity || { set () {} }
+      return state
+    }
+  }
+
+  return { HorsePhysics: StubHorsePhysics, HorseState: StubHorseState }
+}
 
 function buildExports (mode) {
   const exports = { ...realUtil }
@@ -15,31 +53,15 @@ function buildExports (mode) {
     delete exports.HorsePhysics
     delete exports.HorseState
   }
-  if (mode === 'no-transport') {
+  if (mode === 'no-transport' || mode === 'warn-once') {
     delete exports.BoatPhysics
     delete exports.BoatState
   }
+  if (mode === 'full-transport') {
+    Object.assign(exports, createStubHorseExports())
+  }
   return exports
 }
-
-const originalLoad = Module._load
-Module._load = function (request, parent, isMain) {
-  if (request === '@nxg-org/mineflayer-physics-util') {
-    return buildExports(scenario)
-  }
-  return originalLoad.apply(this, arguments)
-}
-
-const mineflayerRoot = path.join(__dirname, '..')
-for (const key of Object.keys(require.cache)) {
-  if (key.startsWith(mineflayerRoot)) {
-    delete require.cache[key]
-  }
-}
-
-const mineflayer = require('../')
-const mc = require('minecraft-protocol')
-const { once } = require('../lib/promise_utils')
 
 function createBlockWorldStub (version, waterSurfaceY = 63) {
   const mcData = require('minecraft-data')(version)
@@ -106,6 +128,10 @@ function setupHorse (bot, vehicleId, position) {
   return horse
 }
 
+function dismountVehicle (bot, vehicleId) {
+  bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [] })
+}
+
 function loginBot (bot, client) {
   client.write('login', bot.test.generateLoginPacket())
   client.write('position', {
@@ -119,122 +145,195 @@ function loginBot (bot, client) {
   })
 }
 
-function withLogin (bot, client, runTest) {
-  return new Promise((resolve, reject) => {
-    bot.once('login', async () => {
-      try {
-        await once(bot, 'forcedMove')
-        await runTest()
-        resolve()
-      } catch (err) {
-        reject(err)
-      }
-    })
-    loginBot(bot, client)
-  })
-}
-
-async function tickPhysics (bot, count = 1) {
-  for (let i = 0; i < count; i++) {
-    await once(bot, 'physicsTick')
-  }
-}
-
-async function withBot (runTest) {
-  const port = 26000 + Math.floor(Math.random() * 1000)
-  const registry = require('prismarine-registry')(supportedVersion)
-  const server = mc.createServer({
-    'online-mode': false,
-    version: supportedVersion,
-    port
-  })
-
-  await new Promise((resolve, reject) => {
-    server.once('listening', resolve)
-    server.once('error', reject)
-  })
-
-  let bot
-  try {
-    await new Promise((resolve, reject) => {
-      server.on('playerJoin', (client) => {
-        withLogin(bot, client, async () => {
-          bot.blockAt = createBlockWorldStub(bot.version)
-          await runTest(bot)
-        }).then(resolve).catch(reject)
-      })
-
-      bot = mineflayer.createBot({
-        username: 'player',
-        version: supportedVersion,
-        port
-      })
-      bot.test = {}
-      bot.test.generateLoginPacket = () => {
-        const loginPacket = registry.loginPacket
-        loginPacket.entityId = 0
-        return loginPacket
-      }
-    })
-  } finally {
-    if (bot && !bot._client.ended) {
-      bot.quit('scenario teardown')
-      await once(bot, 'end')
+async function runWithMode (mode, runTest) {
+  const originalLoad = Module._load
+  Module._load = function (request, parent, isMain) {
+    if (request === '@nxg-org/mineflayer-physics-util') {
+      return buildExports(mode)
     }
-    await new Promise((resolve) => server.close(resolve))
+    return originalLoad.apply(this, arguments)
+  }
+
+  const mineflayerRoot = path.join(__dirname, '..')
+  for (const key of Object.keys(require.cache)) {
+    if (key.startsWith(mineflayerRoot)) {
+      delete require.cache[key]
+    }
+  }
+
+  const mineflayer = require('../')
+  const mc = require('minecraft-protocol')
+  const { once } = require('../lib/promise_utils')
+
+  function withLogin (bot, client, body) {
+    return new Promise((resolve, reject) => {
+      bot.once('login', async () => {
+        try {
+          await once(bot, 'forcedMove')
+          await body()
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      })
+      loginBot(bot, client)
+    })
+  }
+
+  async function tickPhysics (bot, count = 1) {
+    for (let i = 0; i < count; i++) {
+      await once(bot, 'physicsTick')
+    }
+  }
+
+  async function teardownBotAndServer (bot, server) {
+    if (bot && !bot._client.ended) {
+      await Promise.race([
+        once(bot, 'end'),
+        new Promise((resolve) => {
+          setTimeout(() => {
+            try {
+              bot._client.end()
+            } catch {}
+            resolve()
+          }, 1000)
+        })
+      ])
+      try {
+        bot.quit('scenario teardown')
+      } catch {}
+    }
+    await new Promise((resolve) => server.close(() => resolve()))
+  }
+
+  async function withBot (body) {
+    const port = 26000 + Math.floor(Math.random() * 1000)
+    const registry = require('prismarine-registry')(supportedVersion)
+    const server = mc.createServer({
+      'online-mode': false,
+      version: supportedVersion,
+      port
+    })
+
+    await new Promise((resolve, reject) => {
+      server.once('listening', resolve)
+      server.once('error', reject)
+    })
+
+    let bot
+    try {
+      await new Promise((resolve, reject) => {
+        server.once('playerJoin', (client) => {
+          withLogin(bot, client, async () => {
+            bot.blockAt = createBlockWorldStub(bot.version)
+            await body(bot, { tickPhysics })
+          }).then(resolve).catch(reject)
+        })
+
+        bot = mineflayer.createBot({
+          username: 'player',
+          version: supportedVersion,
+          port
+        })
+        bot.test = {}
+        bot.test.generateLoginPacket = () => {
+          const loginPacket = registry.loginPacket
+          loginPacket.entityId = 0
+          return loginPacket
+        }
+      })
+    } finally {
+      await teardownBotAndServer(bot, server)
+    }
+  }
+
+  try {
+    await runTest(withBot)
+  } finally {
+    Module._load = originalLoad
   }
 }
 
-async function main () {
-  if (scenario === 'boats-only') {
-    await withBot(async (bot) => {
+async function runBoatsOnlyScenario () {
+  await runWithMode('boats-only', async (withBot) => {
+    await withBot(async (bot, { tickPhysics }) => {
       assert.strictEqual(bot._horsePhysics.getCtx(), null)
       setupBoat(bot, 42, vec3(0, 63, 0))
       await tickPhysics(bot, 2)
       assert.ok(bot._boatPhysics.getCtx(), 'expected local boat context on supported version')
     })
-    return
-  }
+  })
+}
 
-  if (scenario === 'no-transport') {
-    await withBot(async (bot) => {
+async function runNoTransportScenario () {
+  await runWithMode('no-transport', async (withBot) => {
+    await withBot(async (bot, { tickPhysics }) => {
       setupBoat(bot, 42, vec3(0, 63, 0))
       await tickPhysics(bot, 2)
       assert.strictEqual(bot._boatPhysics.getCtx(), null, 'legacy boat path must not create local context')
       assert.strictEqual(bot._horsePhysics.getCtx(), null)
     })
-    return
-  }
+  })
+}
 
-  if (scenario === 'full-transport') {
-    await withBot(async (bot) => {
+async function runFullTransportScenario () {
+  await runWithMode('full-transport', async (withBot) => {
+    await withBot(async (bot, { tickPhysics }) => {
       setupBoat(bot, 42, vec3(0, 63, 0))
       await tickPhysics(bot, 2)
       assert.ok(bot._boatPhysics.getCtx(), 'expected local boat context when exports are present')
+
+      setupHorse(bot, 43, vec3(2, 63, 0))
+      await tickPhysics(bot, 2)
+      assert.ok(bot._horsePhysics.getCtx(), 'expected local horse context when exports are present')
+      assert.strictEqual(bot._horsePhysics.getCtx().state.constructor.name, 'StubHorseState')
     })
-    return
+  })
+}
+
+async function runWarnOnceScenario () {
+  const warnings = []
+  const originalWarn = console.warn
+  console.warn = (...args) => {
+    warnings.push(args.join(' '))
+    originalWarn.apply(console, args)
   }
 
-  if (scenario === 'warn-once') {
-    const warnings = []
-    const originalWarn = console.warn
-    console.warn = (...args) => {
-      warnings.push(args.join(' '))
-      originalWarn.apply(console, args)
-    }
-    try {
+  try {
+    await runWithMode('warn-once', async (withBot) => {
       await withBot(async (bot) => {
-        setupHorse(bot, 43, vec3(0, 63, 0))
-      })
-      const horseWarnings = warnings.filter((line) => line.includes('local horse physics unavailable'))
-      assert.strictEqual(horseWarnings.length, 1)
-    } finally {
-      console.warn = originalWarn
-    }
-    return
-  }
+        setupBoat(bot, 42, vec3(0, 63, 0))
+        dismountVehicle(bot, 42)
+        setupBoat(bot, 42, vec3(0, 63, 0))
 
-  throw new Error(`unknown scenario: ${scenario}`)
+        setupHorse(bot, 43, vec3(2, 63, 0))
+        dismountVehicle(bot, 43)
+        setupHorse(bot, 44, vec3(3, 63, 0))
+      })
+    })
+
+    const boatWarnings = warnings.filter((line) => line.includes('local boat physics unavailable'))
+    const horseWarnings = warnings.filter((line) => line.includes('local horse physics unavailable'))
+    assert.strictEqual(boatWarnings.length, 1, `expected one boat warning, got ${boatWarnings.length}`)
+    assert.strictEqual(horseWarnings.length, 1, `expected one horse warning, got ${horseWarnings.length}`)
+  } finally {
+    console.warn = originalWarn
+  }
+}
+
+const scenarioRunners = {
+  'boats-only': runBoatsOnlyScenario,
+  'no-transport': runNoTransportScenario,
+  'full-transport': runFullTransportScenario,
+  'warn-once': runWarnOnceScenario
+}
+
+async function main () {
+  for (const scenario of scenarios) {
+    const runner = scenarioRunners[scenario]
+    if (!runner) throw new Error(`unknown scenario: ${scenario}`)
+    await runner()
+  }
 }
 
 main().catch((err) => {

--- a/test/physicsCapabilityScenario.js
+++ b/test/physicsCapabilityScenario.js
@@ -1,0 +1,243 @@
+'use strict'
+
+const assert = require('assert')
+const vec3 = require('vec3')
+const Module = require('module')
+const path = require('path')
+
+const scenario = process.argv[2]
+const supportedVersion = '1.17.1'
+const realUtil = require('@nxg-org/mineflayer-physics-util')
+
+function buildExports (mode) {
+  const exports = { ...realUtil }
+  if (mode === 'boats-only' || mode === 'no-transport' || mode === 'warn-once') {
+    delete exports.HorsePhysics
+    delete exports.HorseState
+  }
+  if (mode === 'no-transport') {
+    delete exports.BoatPhysics
+    delete exports.BoatState
+  }
+  return exports
+}
+
+const originalLoad = Module._load
+Module._load = function (request, parent, isMain) {
+  if (request === '@nxg-org/mineflayer-physics-util') {
+    return buildExports(scenario)
+  }
+  return originalLoad.apply(this, arguments)
+}
+
+const mineflayerRoot = path.join(__dirname, '..')
+for (const key of Object.keys(require.cache)) {
+  if (key.startsWith(mineflayerRoot)) {
+    delete require.cache[key]
+  }
+}
+
+const mineflayer = require('../')
+const mc = require('minecraft-protocol')
+const { once } = require('../lib/promise_utils')
+
+function createBlockWorldStub (version, waterSurfaceY = 63) {
+  const mcData = require('minecraft-data')(version)
+  const Block = require('prismarine-block')(version)
+  const waterId = mcData.blocksByName.water.id
+  const stoneId = mcData.blocksByName.stone.id
+  const airId = mcData.blocksByName.air.id
+  const cache = new Map()
+
+  return (pos) => {
+    const blockPos = pos.floored()
+    const key = `${blockPos.x},${blockPos.y},${blockPos.z}`
+    const cached = cache.get(key)
+    if (cached) return cached
+
+    let type = airId
+    if (blockPos.y < waterSurfaceY - 1) {
+      type = stoneId
+    } else if (blockPos.y === waterSurfaceY - 1) {
+      type = waterId
+    }
+    const block = new Block(type, 0, 0)
+    block.position = blockPos
+    cache.set(key, block)
+    return block
+  }
+}
+
+function setupBoat (bot, vehicleId, position) {
+  const boat = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
+  boat.name = 'boat'
+  boat.position = position.clone ? position.clone() : vec3(position.x, position.y, position.z)
+  boat.width = 1.375
+  boat.height = 0.5625
+  boat.velocity = vec3(0, 0, 0)
+  boat.yaw = 0
+  boat.pitch = 0
+  boat.passengers = [bot.entity]
+  bot.entities[vehicleId] = boat
+  bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+  return boat
+}
+
+function setupHorse (bot, vehicleId, position) {
+  const horse = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
+  horse.name = 'horse'
+  horse.position = position.clone ? position.clone() : vec3(position.x, position.y, position.z)
+  horse.width = 1.3964844
+  horse.height = 1.6
+  horse.velocity = vec3(0, 0, 0)
+  horse.yaw = 0
+  horse.pitch = 0
+  horse.metadata = new Array(18).fill(0)
+  horse.metadata[17] = 0x04
+  horse.attributes = {
+    'generic.movement_speed': { value: 0.225, modifiers: [] },
+    horse_jump_strength: { value: 0.7, modifiers: [] }
+  }
+  horse.effects = []
+  horse.equipment = []
+  horse.passengers = [bot.entity]
+  bot.entities[vehicleId] = horse
+  bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+  return horse
+}
+
+function loginBot (bot, client) {
+  client.write('login', bot.test.generateLoginPacket())
+  client.write('position', {
+    x: 0,
+    y: 64,
+    z: 0,
+    yaw: 0,
+    pitch: 0,
+    flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+    teleportId: 1
+  })
+}
+
+function withLogin (bot, client, runTest) {
+  return new Promise((resolve, reject) => {
+    bot.once('login', async () => {
+      try {
+        await once(bot, 'forcedMove')
+        await runTest()
+        resolve()
+      } catch (err) {
+        reject(err)
+      }
+    })
+    loginBot(bot, client)
+  })
+}
+
+async function tickPhysics (bot, count = 1) {
+  for (let i = 0; i < count; i++) {
+    await once(bot, 'physicsTick')
+  }
+}
+
+async function withBot (runTest) {
+  const port = 26000 + Math.floor(Math.random() * 1000)
+  const registry = require('prismarine-registry')(supportedVersion)
+  const server = mc.createServer({
+    'online-mode': false,
+    version: supportedVersion,
+    port
+  })
+
+  await new Promise((resolve, reject) => {
+    server.once('listening', resolve)
+    server.once('error', reject)
+  })
+
+  let bot
+  try {
+    await new Promise((resolve, reject) => {
+      server.on('playerJoin', (client) => {
+        withLogin(bot, client, async () => {
+          bot.blockAt = createBlockWorldStub(bot.version)
+          await runTest(bot)
+        }).then(resolve).catch(reject)
+      })
+
+      bot = mineflayer.createBot({
+        username: 'player',
+        version: supportedVersion,
+        port
+      })
+      bot.test = {}
+      bot.test.generateLoginPacket = () => {
+        const loginPacket = registry.loginPacket
+        loginPacket.entityId = 0
+        return loginPacket
+      }
+    })
+  } finally {
+    if (bot && !bot._client.ended) {
+      bot.quit('scenario teardown')
+      await once(bot, 'end')
+    }
+    await new Promise((resolve) => server.close(resolve))
+  }
+}
+
+async function main () {
+  if (scenario === 'boats-only') {
+    await withBot(async (bot) => {
+      assert.strictEqual(bot._horsePhysics.getCtx(), null)
+      setupBoat(bot, 42, vec3(0, 63, 0))
+      await tickPhysics(bot, 2)
+      assert.ok(bot._boatPhysics.getCtx(), 'expected local boat context on supported version')
+    })
+    return
+  }
+
+  if (scenario === 'no-transport') {
+    await withBot(async (bot) => {
+      setupBoat(bot, 42, vec3(0, 63, 0))
+      await tickPhysics(bot, 2)
+      assert.strictEqual(bot._boatPhysics.getCtx(), null, 'legacy boat path must not create local context')
+      assert.strictEqual(bot._horsePhysics.getCtx(), null)
+    })
+    return
+  }
+
+  if (scenario === 'full-transport') {
+    await withBot(async (bot) => {
+      setupBoat(bot, 42, vec3(0, 63, 0))
+      await tickPhysics(bot, 2)
+      assert.ok(bot._boatPhysics.getCtx(), 'expected local boat context when exports are present')
+    })
+    return
+  }
+
+  if (scenario === 'warn-once') {
+    const warnings = []
+    const originalWarn = console.warn
+    console.warn = (...args) => {
+      warnings.push(args.join(' '))
+      originalWarn.apply(console, args)
+    }
+    try {
+      await withBot(async (bot) => {
+        setupHorse(bot, 43, vec3(0, 63, 0))
+      })
+      const horseWarnings = warnings.filter((line) => line.includes('local horse physics unavailable'))
+      assert.strictEqual(horseWarnings.length, 1)
+    } finally {
+      console.warn = originalWarn
+    }
+    return
+  }
+
+  throw new Error(`unknown scenario: ${scenario}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/test/physicsCapabilityTest.js
+++ b/test/physicsCapabilityTest.js
@@ -44,10 +44,7 @@ describe('physics capability integration', function () {
   this.timeout(60 * 1000)
 
   it('covers boats-only, legacy fallback, full transport, and warn-once behavior', () => {
-    const startedAt = Date.now()
     const result = runScenarios('all')
-    const elapsedMs = Date.now() - startedAt
     assert.strictEqual(result.status, 0, result.stderr || result.stdout)
-    assert.ok(elapsedMs < 45000, `expected integration scenarios under 45s, took ${elapsedMs}ms`)
   })
 })

--- a/test/physicsCapabilityTest.js
+++ b/test/physicsCapabilityTest.js
@@ -1,0 +1,65 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const { spawnSync } = require('child_process')
+const path = require('path')
+const {
+  hasTransportPhysicsCapability,
+  resolveTransportPhysicsCapabilities
+} = require('../lib/physicsCapabilities')
+
+function runScenario (scenario) {
+  const script = path.join(__dirname, 'physicsCapabilityScenario.js')
+  return spawnSync(process.execPath, [script, scenario], {
+    encoding: 'utf8',
+    env: process.env
+  })
+}
+
+describe('physics capability helper', () => {
+  it('detects boat capability from constructor and CREATE_FROM_ENTITY', () => {
+    class BoatPhysics {}
+    const BoatState = { CREATE_FROM_ENTITY () {} }
+    assert.strictEqual(hasTransportPhysicsCapability(BoatPhysics, BoatState), true)
+  })
+
+  it('rejects partial boat exports', () => {
+    class BoatPhysics {}
+    assert.strictEqual(hasTransportPhysicsCapability(BoatPhysics, {}), false)
+    assert.strictEqual(hasTransportPhysicsCapability(undefined, { CREATE_FROM_ENTITY () {} }), false)
+  })
+
+  it('resolves boat-only capabilities from export sets', () => {
+    class BoatPhysics {}
+    const BoatState = { CREATE_FROM_ENTITY () {} }
+    const caps = resolveTransportPhysicsCapabilities({
+      BoatPhysics,
+      BoatState
+    })
+    assert.deepStrictEqual(caps, { boat: true, horse: false })
+  })
+})
+
+describe('physics capability integration', function () {
+  this.timeout(60 * 1000)
+
+  it('starts with boat exports present and horse exports absent', () => {
+    const result = runScenario('boats-only')
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout)
+  })
+
+  it('starts with boat and horse exports absent and keeps legacy boat path', () => {
+    const result = runScenario('no-transport')
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout)
+  })
+
+  it('keeps full transport behavior when all exports are present', () => {
+    const result = runScenario('full-transport')
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout)
+  })
+
+  it('logs a missing capability warning only once per capability', () => {
+    const result = runScenario('warn-once')
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout)
+  })
+})

--- a/test/physicsCapabilityTest.js
+++ b/test/physicsCapabilityTest.js
@@ -8,7 +8,7 @@ const {
   resolveTransportPhysicsCapabilities
 } = require('../lib/physicsCapabilities')
 
-function runScenario (scenario) {
+function runScenarios (scenario = 'all') {
   const script = path.join(__dirname, 'physicsCapabilityScenario.js')
   return spawnSync(process.execPath, [script, scenario], {
     encoding: 'utf8',
@@ -43,23 +43,11 @@ describe('physics capability helper', () => {
 describe('physics capability integration', function () {
   this.timeout(60 * 1000)
 
-  it('starts with boat exports present and horse exports absent', () => {
-    const result = runScenario('boats-only')
+  it('covers boats-only, legacy fallback, full transport, and warn-once behavior', () => {
+    const startedAt = Date.now()
+    const result = runScenarios('all')
+    const elapsedMs = Date.now() - startedAt
     assert.strictEqual(result.status, 0, result.stderr || result.stdout)
-  })
-
-  it('starts with boat and horse exports absent and keeps legacy boat path', () => {
-    const result = runScenario('no-transport')
-    assert.strictEqual(result.status, 0, result.stderr || result.stdout)
-  })
-
-  it('keeps full transport behavior when all exports are present', () => {
-    const result = runScenario('full-transport')
-    assert.strictEqual(result.status, 0, result.stderr || result.stdout)
-  })
-
-  it('logs a missing capability warning only once per capability', () => {
-    const result = runScenario('warn-once')
-    assert.strictEqual(result.status, 0, result.stderr || result.stdout)
+    assert.ok(elapsedMs < 45000, `expected integration scenarios under 45s, took ${elapsedMs}ms`)
   })
 })

--- a/test/vehicleLifecycleTest.js
+++ b/test/vehicleLifecycleTest.js
@@ -278,6 +278,56 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
 
+      it('emits remote passenger attach and detach after updating vehicle state', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', () => {
+            const firstVehicleId = 100
+            const secondVehicleId = 101
+            const passengerId = 200
+            const events = []
+
+            bot.on('entityAttach', (passenger, vehicle) => {
+              if (passenger.id !== passengerId) return
+              events.push({
+                type: 'attach',
+                vehicleId: vehicle.id,
+                passengerVehicleId: passenger.vehicle?.id,
+                vehiclePassengerIds: vehicle.passengers.map(({ id }) => id)
+              })
+            })
+            bot.on('entityDetach', (passenger, vehicle) => {
+              if (passenger.id !== passengerId) return
+              events.push({
+                type: 'detach',
+                vehicleId: vehicle.id,
+                passengerVehicleId: passenger.vehicle?.id ?? null,
+                vehiclePassengerIds: vehicle.passengers.map(({ id }) => id)
+              })
+            })
+
+            bot._client.emit('set_passengers', { entityId: firstVehicleId, passengers: [passengerId] })
+            bot._client.emit('set_passengers', { entityId: firstVehicleId, passengers: [passengerId] })
+            bot._client.emit('set_passengers', { entityId: secondVehicleId, passengers: [passengerId] })
+            bot._client.emit('set_passengers', { entityId: secondVehicleId, passengers: [passengerId] })
+            bot._client.emit('set_passengers', { entityId: secondVehicleId, passengers: [] })
+            bot._client.emit('set_passengers', { entityId: secondVehicleId, passengers: [] })
+
+            assert.deepStrictEqual(events, [
+              { type: 'attach', vehicleId: firstVehicleId, passengerVehicleId: firstVehicleId, vehiclePassengerIds: [passengerId] },
+              { type: 'detach', vehicleId: firstVehicleId, passengerVehicleId: null, vehiclePassengerIds: [] },
+              { type: 'attach', vehicleId: secondVehicleId, passengerVehicleId: secondVehicleId, vehiclePassengerIds: [passengerId] },
+              { type: 'detach', vehicleId: secondVehicleId, passengerVehicleId: null, vehiclePassengerIds: [] }
+            ])
+            assert.deepStrictEqual(bot.entities[firstVehicleId].passengers, [])
+            assert.deepStrictEqual(bot.entities[secondVehicleId].passengers, [])
+            assert.strictEqual(bot.entities[passengerId].vehicle, null)
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
       it('offsets player outside boat on dismount and keeps them there', (done) => {
         server.on('playerJoin', (client) => {
           bot.once('login', async () => {

--- a/test/vehicleLifecycleTest.js
+++ b/test/vehicleLifecycleTest.js
@@ -387,6 +387,294 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     }
 
+    if (supportedVersion === '1.17.1' && hasSetPassengers) {
+      const POST_DISMOUNT_TIMEOUT_MS = 3000
+
+      function makePositionPacket (x, y, z, { dismountVehicle, teleportId }) {
+        const packet = {
+          x,
+          y,
+          z,
+          yaw: 0,
+          pitch: 0,
+          flags: bot.supportFeature('positionPacketHasBitflags')
+            ? { x: false, y: false, z: false, yaw: false, pitch: false }
+            : 0,
+          teleportId
+        }
+        if (dismountVehicle === true) packet.dismountVehicle = true
+        return packet
+      }
+
+      function boatDismountPosition (boat) {
+        return {
+          x: boat.position.x,
+          y: boat.position.y + boat.height,
+          z: boat.position.z
+        }
+      }
+
+      function assertBoatDismountOutcome (boat, dismountCount) {
+        assert.strictEqual(bot.vehicle, null)
+        assert.strictEqual(bot.entity.vehicle, undefined)
+        assert.strictEqual(dismountCount, 1)
+        assert.strictEqual(bot._boatPhysics.getCtx(), null)
+        assert.ok(
+          isOutsideBoatHorizontalAabb(bot.entity.position.x, bot.entity.position.z, boat),
+          'player must be outside boat horizontal AABB after dismount'
+        )
+      }
+
+      async function setupMountedBoat (vehicleId, position) {
+        stubPassableWorld()
+        const boat = setupBoat(vehicleId, position)
+        await once(bot, 'physicsTick')
+        assert(bot._boatPhysics.getCtx(), 'expected boat physics context while mounted')
+        return boat
+      }
+
+      it('sequence A: position(dismount) then set_passengers(empty) offsets player outside boat', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            const boat = await setupMountedBoat(100, vec3(10, 63, 20))
+            let dismountCount = 0
+            bot.on('dismount', () => { dismountCount++ })
+
+            const onBoat = boatDismountPosition(boat)
+            bot._client.emit('position', makePositionPacket(onBoat.x, onBoat.y, onBoat.z, {
+              dismountVehicle: true,
+              teleportId: 2
+            }))
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+
+            assertBoatDismountOutcome(boat, dismountCount)
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+            assertBoatDismountOutcome(boat, dismountCount)
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('sequence B: set_passengers(empty) then position(dismount) offsets player outside boat', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            const boat = await setupMountedBoat(100, vec3(10, 63, 20))
+            let dismountCount = 0
+            bot.on('dismount', () => { dismountCount++ })
+
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+            const onBoat = boatDismountPosition(boat)
+            bot._client.emit('position', makePositionPacket(onBoat.x, onBoat.y, onBoat.z, {
+              dismountVehicle: true,
+              teleportId: 2
+            }))
+
+            assertBoatDismountOutcome(boat, dismountCount)
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('delayed sequence B: set_passengers then physicsTick then position(dismount) offsets player', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            const boat = await setupMountedBoat(100, vec3(10, 63, 20))
+            let dismountCount = 0
+            bot.on('dismount', () => { dismountCount++ })
+
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+            await once(bot, 'physicsTick')
+            const onBoat = boatDismountPosition(boat)
+            bot._client.emit('position', makePositionPacket(onBoat.x, onBoat.y, onBoat.z, {
+              dismountVehicle: true,
+              teleportId: 2
+            }))
+
+            assertBoatDismountOutcome(boat, dismountCount)
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('position(dismount=false) does not consume pending post-dismount offset', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            const boat = await setupMountedBoat(100, vec3(10, 63, 20))
+
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+            const afterDismount = bot.entity.position.clone()
+
+            bot._client.emit('position', makePositionPacket(12, 64, 22, {
+              teleportId: 3
+            }))
+            assert.strictEqual(bot.entity.position.x, 12)
+            assert.strictEqual(bot.entity.position.y, 64)
+            assert.strictEqual(bot.entity.position.z, 22)
+
+            const onBoat = boatDismountPosition(boat)
+            bot._client.emit('position', makePositionPacket(onBoat.x, onBoat.y, onBoat.z, {
+              dismountVehicle: true,
+              teleportId: 4
+            }))
+            assert.ok(
+              isOutsideBoatHorizontalAabb(bot.entity.position.x, bot.entity.position.z, boat),
+              'pending offset must still apply on later dismount position packet'
+            )
+            assert.notStrictEqual(bot.entity.position.x, afterDismount.x)
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('reapplies offset for repeated dismount position packets inside boat AABB', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            const boat = await setupMountedBoat(100, vec3(10, 63, 20))
+            let dismountCount = 0
+            bot.on('dismount', () => { dismountCount++ })
+
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+            const onBoat = boatDismountPosition(boat)
+
+            bot._client.emit('position', makePositionPacket(onBoat.x, onBoat.y, onBoat.z, {
+              dismountVehicle: true,
+              teleportId: 2
+            }))
+            assertBoatDismountOutcome(boat, dismountCount)
+
+            bot._client.emit('position', makePositionPacket(onBoat.x, onBoat.y, onBoat.z, {
+              dismountVehicle: true,
+              teleportId: 3
+            }))
+            assertBoatDismountOutcome(boat, dismountCount)
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('later dismount position outside boat AABB is not re-offset', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            const boat = await setupMountedBoat(100, vec3(10, 63, 20))
+
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+            const onBoat = boatDismountPosition(boat)
+            bot._client.emit('position', makePositionPacket(onBoat.x, onBoat.y, onBoat.z, {
+              dismountVehicle: true,
+              teleportId: 2
+            }))
+            const afterOffset = bot.entity.position.clone()
+
+            bot._client.emit('position', makePositionPacket(15, 64, 25, {
+              dismountVehicle: true,
+              teleportId: 3
+            }))
+            assert.strictEqual(bot.entity.position.x, 15)
+            assert.strictEqual(bot.entity.position.y, 64)
+            assert.strictEqual(bot.entity.position.z, 25)
+            assert.notStrictEqual(bot.entity.position.x, afterOffset.x)
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('sendPacketPositionAndLook acknowledges server target before post-dismount offset', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            const boat = await setupMountedBoat(100, vec3(10, 63, 20))
+            const writes = captureWrites()
+            const onBoat = boatDismountPosition(boat)
+
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+            writes.length = 0
+            bot._client.emit('position', makePositionPacket(onBoat.x, onBoat.y, onBoat.z, {
+              dismountVehicle: true,
+              teleportId: 2
+            }))
+
+            const positionLook = writes.find(w => w.name === 'position_look')
+            assert(positionLook, 'expected position_look response')
+            assert.strictEqual(positionLook.data.x, onBoat.x)
+            assert.strictEqual(positionLook.data.y, onBoat.y)
+            assert.strictEqual(positionLook.data.z, onBoat.z)
+            assert.ok(
+              isOutsideBoatHorizontalAabb(bot.entity.position.x, bot.entity.position.z, boat),
+              'local position must be offset after acknowledgement'
+            )
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('pending post-dismount state expires after 3 seconds', function (done) {
+        this.timeout(6000)
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            const boat = await setupMountedBoat(100, vec3(10, 63, 20))
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+
+            await new Promise(resolve => setTimeout(resolve, POST_DISMOUNT_TIMEOUT_MS + 100))
+
+            const onBoat = boatDismountPosition(boat)
+            bot._client.emit('position', makePositionPacket(onBoat.x, onBoat.y, onBoat.z, {
+              dismountVehicle: true,
+              teleportId: 2
+            }))
+
+            assert.strictEqual(bot.entity.position.x, onBoat.x)
+            assert.strictEqual(bot.entity.position.y, onBoat.y)
+            assert.strictEqual(bot.entity.position.z, onBoat.z)
+            assert.ok(
+              !isOutsideBoatHorizontalAabb(bot.entity.position.x, bot.entity.position.z, boat),
+              'expired pending state must not reapply offset'
+            )
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('new mount clears stale pending post-dismount state', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            const boat = await setupMountedBoat(100, vec3(10, 63, 20))
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+
+            bot._client.emit('set_passengers', { entityId: 100, passengers: [bot.entity.id] })
+            await once(bot, 'physicsTick')
+
+            const onBoat = boatDismountPosition(boat)
+            bot._client.emit('position', makePositionPacket(onBoat.x, onBoat.y, onBoat.z, {
+              dismountVehicle: true,
+              teleportId: 2
+            }))
+
+            assert.strictEqual(bot.vehicle, null)
+            assert.ok(
+              isOutsideBoatHorizontalAabb(bot.entity.position.x, bot.entity.position.z, boat),
+              'forced dismount after remount must still offset using fresh pending state'
+            )
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+    }
+
     if (usesLegacySteerVehicle) {
       it('setControlState sneak only dismounts on press, not release', (done) => {
         server.on('playerJoin', (client) => {

--- a/test/vehicleLifecycleTest.js
+++ b/test/vehicleLifecycleTest.js
@@ -1,0 +1,356 @@
+/* eslint-env mocha */
+
+const mineflayer = require('../')
+const mc = require('minecraft-protocol')
+const vec3 = require('vec3')
+const assert = require('assert')
+const { once } = require('../lib/promise_utils')
+
+for (const supportedVersion of mineflayer.testedVersions) {
+  const registry = require('prismarine-registry')(supportedVersion)
+  const Block = require('prismarine-block')(supportedVersion)
+  const hasSetPassengers = registry.version['>=']('1.9')
+  const usesLegacySteerVehicle = !registry.supportFeature('newPlayerInputPacket')
+
+  describe(`mineflayer_vehicle_lifecycle ${supportedVersion}v`, function () {
+    this.timeout(10 * 1000)
+    let bot
+    let server
+
+    beforeEach((done) => {
+      server = mc.createServer({
+        'online-mode': false,
+        version: supportedVersion,
+        port: 25568
+      })
+      server.on('listening', () => {
+        bot = mineflayer.createBot({
+          username: 'player',
+          version: supportedVersion,
+          port: 25568
+        })
+        bot.test = {}
+        bot.test.generateLoginPacket = () => {
+          if (bot.supportFeature('usesLoginPacket')) {
+            const loginPacket = registry.loginPacket
+            loginPacket.entityId = 0
+            return loginPacket
+          }
+          return {
+            entityId: 0,
+            levelType: 'fogetaboutit',
+            gameMode: 0,
+            previousGameMode: 255,
+            worldNames: ['minecraft:overworld'],
+            dimension: 0,
+            worldName: 'minecraft:overworld',
+            hashedSeed: [0, 0],
+            difficulty: 0,
+            maxPlayers: 20,
+            reducedDebugInfo: 1,
+            enableRespawnScreen: true
+          }
+        }
+        done()
+      })
+    })
+
+    afterEach((done) => {
+      bot.on('end', () => done())
+      server.close()
+    })
+
+    function captureWrites () {
+      const writes = []
+      const oldWrite = bot._client.write
+      bot._client.write = function (name, data) {
+        writes.push({ name, data })
+        return oldWrite.apply(bot._client, arguments)
+      }
+      return writes
+    }
+
+    function loginBot (client) {
+      client.write('login', bot.test.generateLoginPacket())
+      client.write('position', {
+        x: 0,
+        y: 64,
+        z: 0,
+        yaw: 0,
+        pitch: 0,
+        flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+        teleportId: 1
+      })
+    }
+
+    function stubPassableWorld () {
+      const air = Block.fromStateId(0, 0)
+      bot.blockAt = () => air
+    }
+
+    function isOutsideBoatHorizontalAabb (x, z, boat) {
+      const halfWidth = boat.width / 2
+      return Math.abs(x - boat.position.x) > halfWidth || Math.abs(z - boat.position.z) > halfWidth
+    }
+
+    function setupBoat (vehicleId, position) {
+      const boat = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
+      boat.name = 'boat'
+      boat.position = position
+      boat.width = 1.375
+      boat.height = 0.5625
+      boat.velocity = vec3(0, 0, 0)
+      bot.entities[vehicleId] = boat
+      bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+      return bot.entities[vehicleId]
+    }
+
+    if (usesLegacySteerVehicle) {
+      it('moveVehicle(0, 0, false) sends steer_vehicle jump mask 0', (done) => {
+        server.on('playerJoin', (client) => {
+          loginBot(client)
+          const writes = captureWrites()
+          bot.moveVehicle(0, 0, false)
+          const packet = writes.find(w => w.name === 'steer_vehicle')
+          assert(packet, 'expected steer_vehicle packet')
+          assert.strictEqual(packet.data.jump, 0)
+          done()
+        })
+      })
+
+      it('moveVehicle(0, 0, true) sends steer_vehicle jump mask 1', (done) => {
+        server.on('playerJoin', (client) => {
+          loginBot(client)
+          const writes = captureWrites()
+          bot.moveVehicle(0, 0, true)
+          const packet = writes.find(w => w.name === 'steer_vehicle')
+          assert(packet, 'expected steer_vehicle packet')
+          assert.strictEqual(packet.data.jump, 0x01)
+          done()
+        })
+      })
+
+      it('dismount() sends steer_vehicle jump mask 2', (done) => {
+        server.on('playerJoin', (client) => {
+          loginBot(client)
+          const vehicleId = 42
+          bot.entities[vehicleId] = bot.entities[vehicleId] || { id: vehicleId, passengers: [] }
+          bot.vehicle = bot.entities[vehicleId]
+          const writes = captureWrites()
+          bot.dismount()
+          const packet = writes.find(w => w.name === 'steer_vehicle')
+          assert(packet, 'expected steer_vehicle packet')
+          assert.strictEqual(packet.data.jump, 0x02)
+          done()
+        })
+      })
+
+      if (hasSetPassengers) {
+        it('keeps dismount bit on steer_vehicle until set_passengers confirms', (done) => {
+          server.on('playerJoin', (client) => {
+            bot.once('login', async () => {
+              bot.blockAt = () => ({})
+
+              const vehicleId = 100
+              bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+
+              const writes = captureWrites()
+              bot.dismount()
+
+              for (let i = 0; i < 4; i++) {
+                await once(bot, 'physicsTick')
+              }
+
+              const duringDismount = writes.filter(w => w.name === 'steer_vehicle')
+              assert(duringDismount.length >= 5, 'expected dismount + physics steer_vehicle packets')
+              for (const packet of duringDismount) {
+                assert.strictEqual(packet.data.jump & 0x02, 0x02, `expected dismount bit, got jump=${packet.data.jump}`)
+                assert.notStrictEqual(packet.data.jump, 0, 'periodic steer_vehicle must not clear dismount bit')
+              }
+
+              bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [] })
+              assert.strictEqual(bot.vehicle, null)
+
+              writes.length = 0
+              bot.moveVehicle(0, 0, false)
+              const afterConfirm = writes.filter(w => w.name === 'steer_vehicle')
+              assert.strictEqual(afterConfirm.length, 1)
+              assert.strictEqual(afterConfirm[0].data.jump, 0)
+
+              done()
+            })
+            loginBot(client)
+          })
+        })
+      }
+    }
+
+    if (hasSetPassengers) {
+      it('syncs mounted player state from vehicle on physicsTick', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            // tickPhysics bails when blockAt returns null; stub so the mounted path is testable
+            // without version-specific map_chunk wiring.
+            bot.blockAt = () => ({})
+
+            const vehicleId = 100
+            bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+            const vehicle = bot.entities[vehicleId]
+            vehicle.position = vec3(1, 63, 2)
+            vehicle.velocity = vec3(0.25, 0.1, -0.5)
+            vehicle.height = 1
+            vehicle.onGround = true
+            bot.entity.position.set(0, 50, 0)
+            bot.entity.velocity.set(0, -5, 0)
+            const positionRef = bot.entity.position
+
+            await once(bot, 'physicsTick')
+
+            assert.strictEqual(bot.entity.position, positionRef, 'position Vec3 must not be replaced')
+            assert.strictEqual(bot.entity.position.x, 1)
+            assert.strictEqual(bot.entity.position.y, 64)
+            assert.strictEqual(bot.entity.position.z, 2)
+            assert.strictEqual(bot.entity.velocity.x, 0.25)
+            assert.strictEqual(bot.entity.velocity.y, 0.1)
+            assert.strictEqual(bot.entity.velocity.z, -0.5)
+            assert.strictEqual(bot.entity.onGround, true)
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('set_passengers mount and dismount lifecycle', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', () => {
+            const vehicleId = 100
+            let mountCount = 0
+            let dismountCount = 0
+            bot.on('mount', () => { mountCount++ })
+            bot.on('dismount', () => { dismountCount++ })
+
+            bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+            assert.strictEqual(bot.vehicle?.id, vehicleId)
+            assert.strictEqual(bot.entity.vehicle?.id, vehicleId)
+            assert.strictEqual(mountCount, 1)
+            assert.strictEqual(dismountCount, 0)
+
+            bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+            assert.strictEqual(mountCount, 1, 'duplicate mount packet must not re-emit mount')
+            assert.strictEqual(dismountCount, 0)
+
+            bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [] })
+            assert.strictEqual(bot.vehicle, null)
+            assert.strictEqual(bot.entity.vehicle, undefined)
+            assert.strictEqual(mountCount, 1)
+            assert.strictEqual(dismountCount, 1)
+
+            bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [] })
+            assert.strictEqual(dismountCount, 1, 'duplicate dismount packet must not re-emit dismount')
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('set_passengers removes absent passengers from vehicle.passengers', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', () => {
+            const vehicleId = 100
+            const otherPassengerId = 200
+            bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id, otherPassengerId] })
+
+            const vehicle = bot.entities[vehicleId]
+            assert.strictEqual(vehicle.passengers.length, 2)
+
+            bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+            assert.strictEqual(vehicle.passengers.length, 1)
+            assert.strictEqual(vehicle.passengers[0].id, bot.entity.id)
+            assert.strictEqual(bot.entities[otherPassengerId].vehicle, null)
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('offsets player outside boat on dismount and keeps them there', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            stubPassableWorld()
+
+            const vehicleId = 100
+            const boat = setupBoat(vehicleId, vec3(10, 63, 20))
+
+            await once(bot, 'physicsTick')
+            const boatCenterX = boat.position.x
+            const boatCenterZ = boat.position.z
+            const positionRef = bot.entity.position
+
+            bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [] })
+
+            assert.strictEqual(bot.vehicle, null)
+            assert.strictEqual(bot.entity.vehicle, undefined)
+            assert.strictEqual(bot.entity.position, positionRef)
+            assert.strictEqual(bot.entity.position.y, boat.position.y + boat.height)
+            assert.ok(
+              isOutsideBoatHorizontalAabb(bot.entity.position.x, bot.entity.position.z, boat),
+              'player must be outside boat horizontal AABB after dismount'
+            )
+
+            const afterFirstOffset = bot.entity.position.clone()
+            bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [] })
+            assert.strictEqual(bot.entity.position.x, afterFirstOffset.x)
+            assert.strictEqual(bot.entity.position.y, afterFirstOffset.y)
+            assert.strictEqual(bot.entity.position.z, afterFirstOffset.z)
+
+            for (let i = 0; i < 3; i++) {
+              await once(bot, 'physicsTick')
+            }
+            assert.ok(
+              isOutsideBoatHorizontalAabb(bot.entity.position.x, bot.entity.position.z, boat),
+              'player must stay outside boat after subsequent physics ticks'
+            )
+            assert.ok(
+              Math.abs(bot.entity.position.x - boatCenterX) > boat.width / 2 ||
+              Math.abs(bot.entity.position.z - boatCenterZ) > boat.width / 2,
+              'player must not remain at boat center'
+            )
+
+            const xBefore = bot.entity.position.x
+            const zBefore = bot.entity.position.z
+            bot.setControlState('forward', true)
+            await once(bot, 'physicsTick')
+            await once(bot, 'physicsTick')
+            bot.setControlState('forward', false)
+            const moved = (bot.entity.position.x - xBefore) ** 2 + (bot.entity.position.z - zBefore) ** 2 > 1e-8
+            assert.ok(moved, 'forward control should move player after boat dismount')
+
+            done()
+          })
+          loginBot(client)
+        })
+      })
+    }
+
+    if (usesLegacySteerVehicle) {
+      it('setControlState sneak only dismounts on press, not release', (done) => {
+        server.on('playerJoin', (client) => {
+          loginBot(client)
+          const vehicleId = 42
+          bot.entities[vehicleId] = bot.entities[vehicleId] || { id: vehicleId, passengers: [] }
+          bot.vehicle = bot.entities[vehicleId]
+
+          const writes = captureWrites()
+          bot.setControlState('sneak', true)
+          bot.setControlState('sneak', false)
+
+          const dismountPackets = writes.filter(w => w.name === 'steer_vehicle' && w.data.jump === 0x02)
+          assert.strictEqual(dismountPackets.length, 1, 'expected exactly one dismount packet on sneak press')
+          done()
+        })
+      })
+    }
+  })
+}

--- a/test/vehicleLifecycleTest.js
+++ b/test/vehicleLifecycleTest.js
@@ -100,6 +100,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
       boat.width = 1.375
       boat.height = 0.5625
       boat.velocity = vec3(0, 0, 0)
+      boat.metadata ??= []
+      boat.effects ??= []
+      boat.equipment ??= []
       bot.entities[vehicleId] = boat
       bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
       return bot.entities[vehicleId]

--- a/test/vehicleLifecycleTest.js
+++ b/test/vehicleLifecycleTest.js
@@ -93,9 +93,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
       return Math.abs(x - boat.position.x) > halfWidth || Math.abs(z - boat.position.z) > halfWidth
     }
 
-    function setupBoat (vehicleId, position) {
+    function setupBoat (vehicleId, position, name = 'boat') {
       const boat = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
-      boat.name = 'boat'
+      boat.name = name
       boat.position = position
       boat.width = 1.375
       boat.height = 0.5625
@@ -104,6 +104,36 @@ for (const supportedVersion of mineflayer.testedVersions) {
       boat.effects ??= []
       boat.equipment ??= []
       bot.entities[vehicleId] = boat
+      bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+      return bot.entities[vehicleId]
+    }
+
+    function setupMinecart (vehicleId, position) {
+      const minecart = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
+      minecart.name = 'minecart'
+      minecart.position = position
+      minecart.width = 0.98
+      minecart.height = 0.7
+      minecart.velocity = vec3(0, 0, 0)
+      minecart.metadata ??= []
+      minecart.effects ??= []
+      minecart.equipment ??= []
+      bot.entities[vehicleId] = minecart
+      bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+      return bot.entities[vehicleId]
+    }
+
+    function setupHorse (vehicleId, position) {
+      const horse = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
+      horse.name = 'horse'
+      horse.position = position
+      horse.width = 1.4
+      horse.height = 1.6
+      horse.velocity = vec3(0, 0, 0)
+      horse.metadata ??= []
+      horse.effects ??= []
+      horse.equipment ??= []
+      bot.entities[vehicleId] = horse
       bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
       return bot.entities[vehicleId]
     }
@@ -251,6 +281,100 @@ for (const supportedVersion of mineflayer.testedVersions) {
             bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [] })
             assert.strictEqual(dismountCount, 1, 'duplicate dismount packet must not re-emit dismount')
 
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      it('snaps boat passenger position on mount and emits one move event', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', () => {
+            const oldPos = bot.entity.position.clone()
+            const moves = []
+            bot.on('move', previousPosition => moves.push(previousPosition))
+
+            const boat = setupBoat(100, vec3(1, 63, 2))
+            const expectedOffset = registry.isNewerOrEqualTo('1.20.2') ? -0.4125 : -0.45
+
+            assert.strictEqual(bot.entity.position.x, boat.position.x)
+            assert.strictEqual(bot.entity.position.y, boat.position.y + expectedOffset)
+            assert.strictEqual(bot.entity.position.z, boat.position.z)
+            assert.strictEqual(moves.length, 1)
+            assert(moves[0].equals(oldPos), 'move event must contain the pre-mount position')
+            done()
+          })
+          loginBot(client)
+        })
+      })
+
+      if (['1.20.1', '1.20.2', '1.21.4'].includes(supportedVersion)) {
+        it('snaps modern minecart passenger position on mount', (done) => {
+          server.on('playerJoin', (client) => {
+            bot.once('login', async () => {
+              bot.entity.position.set(0, 50, 0)
+              const oldPos = bot.entity.position.clone()
+              const moves = []
+              bot.on('move', previousPosition => moves.push(previousPosition))
+
+              const minecart = setupMinecart(100, vec3(1, 63, 2))
+              const expectedOffset = supportedVersion === '1.20.1' ? -0.35 : -0.4125
+
+              assert.strictEqual(bot.entity.position.x, minecart.position.x)
+              assert.strictEqual(bot.entity.position.y, minecart.position.y + expectedOffset)
+              assert.strictEqual(bot.entity.position.z, minecart.position.z)
+              assert.strictEqual(moves.length, 1)
+              assert(moves[0].equals(oldPos), 'move event must contain the pre-mount position')
+              done()
+            })
+            loginBot(client)
+          })
+        })
+      }
+
+      if (supportedVersion === '1.21.4') {
+        it('uses the modern bamboo raft passenger offset', (done) => {
+          server.on('playerJoin', (client) => {
+            bot.once('login', async () => {
+              bot.entity.position.set(0, 50, 0)
+              const oldPos = bot.entity.position.clone()
+              const moves = []
+              bot.on('move', previousPosition => moves.push(previousPosition))
+
+              const raft = setupBoat(100, vec3(1, 63, 2), 'bamboo_raft')
+
+              assert.strictEqual(bot.entity.position.x, raft.position.x)
+              assert.ok(Math.abs(bot.entity.position.y - (raft.position.y - 0.1)) < 1e-6)
+              assert.strictEqual(bot.entity.position.z, raft.position.z)
+              assert.strictEqual(moves.length, 1)
+              assert(moves[0].equals(oldPos), 'move event must contain the pre-mount position')
+              done()
+            })
+            loginBot(client)
+          })
+        })
+      }
+
+      it('preserves the existing horse passenger sync behavior', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', async () => {
+            bot.entity.position.set(0, 50, 0)
+            bot.blockAt = () => ({})
+            const oldPos = bot.entity.position.clone()
+            const moves = []
+            bot.on('move', previousPosition => moves.push(previousPosition))
+            const horse = setupHorse(100, vec3(1, 63, 2))
+
+            if (supportedVersion === '1.17.1') {
+              assert.strictEqual(bot.entity.position.y, horse.position.y + 0.85)
+              assert.strictEqual(moves.length, 1)
+            } else {
+              assert(bot.entity.position.equals(oldPos), 'horse mount must not resync immediately')
+              assert.strictEqual(moves.length, 0)
+            }
+
+            await once(bot, 'physicsTick')
+            assert.strictEqual(bot.entity.position.y, supportedVersion === '1.17.1' ? horse.position.y + 0.85 : horse.position.y + horse.height)
             done()
           })
           loginBot(client)

--- a/test/vehiclePhysicsTest.js
+++ b/test/vehiclePhysicsTest.js
@@ -1,0 +1,513 @@
+/* eslint-env mocha */
+
+const mineflayer = require('../')
+const mc = require('minecraft-protocol')
+const vec3 = require('vec3')
+const assert = require('assert')
+const { once } = require('../lib/promise_utils')
+
+function createBlockWorldStub (version, waterSurfaceY = 63) {
+  const mcData = require('minecraft-data')(version)
+  const Block = require('prismarine-block')(version)
+  const waterId = mcData.blocksByName.water.id
+  const stoneId = mcData.blocksByName.stone.id
+  const airId = mcData.blocksByName.air.id
+  const cache = new Map()
+
+  return (pos) => {
+    const blockPos = pos.floored()
+    const key = `${blockPos.x},${blockPos.y},${blockPos.z}`
+    const cached = cache.get(key)
+    if (cached) return cached
+
+    let type = airId
+    if (blockPos.y < waterSurfaceY - 1) {
+      type = stoneId
+    } else if (blockPos.y === waterSurfaceY - 1) {
+      type = waterId
+    }
+    const block = new Block(type, 0, 0)
+    block.position = blockPos
+    cache.set(key, block)
+    return block
+  }
+}
+
+function stubLoadedWorld (bot, waterSurfaceY = 63) {
+  bot.blockAt = createBlockWorldStub(bot.version, waterSurfaceY)
+}
+
+function stubUnloadedWorld (bot) {
+  let calls = 0
+  const loaded = createBlockWorldStub(bot.version)
+  bot.blockAt = (pos) => {
+    calls++
+    if (calls > 20) return null
+    return loaded(pos)
+  }
+}
+
+function captureWrites (bot) {
+  const writes = []
+  const oldWrite = bot._client.write
+  bot._client.write = function (name, data) {
+    writes.push({ name, data })
+    return oldWrite.apply(bot._client, arguments)
+  }
+  return writes
+}
+
+function loginBot (bot, client) {
+  client.write('login', bot.test.generateLoginPacket())
+  client.write('position', {
+    x: 0,
+    y: 64,
+    z: 0,
+    yaw: 0,
+    pitch: 0,
+    flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+    teleportId: 1
+  })
+}
+
+function setupBoat (bot, vehicleId, position) {
+  const boat = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
+  boat.name = 'boat'
+  boat.position = position.clone ? position.clone() : vec3(position.x, position.y, position.z)
+  boat.width = 1.375
+  boat.height = 0.5625
+  boat.velocity = vec3(0, 0, 0)
+  boat.yaw = 0
+  boat.pitch = 0
+  bot.entities[vehicleId] = boat
+  bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
+  return boat
+}
+
+function assertNoBoatCtx (bot, message = 'boatCtx must be destroyed') {
+  assert.ok(bot._boatPhysics.getCtx() == null, message)
+}
+
+function teardownBotAndServer (bot, server, done) {
+  let finished = false
+  function finish () {
+    if (finished) return
+    finished = true
+    done()
+  }
+
+  setTimeout(finish, 3000)
+
+  if (bot && !bot._client.ended) {
+    bot.once('end', () => {
+      if (server) server.close(() => finish())
+      else finish()
+    })
+    try {
+      bot.quit('test teardown')
+    } catch (err) {
+      if (server) server.close(() => finish())
+      else finish()
+    }
+    return
+  }
+
+  if (server) server.close(() => finish())
+  else finish()
+}
+
+function withLogin (bot, client, done, runTest) {
+  bot.once('login', () => {
+    void runTest().then(() => done(), done)
+  })
+  loginBot(bot, client)
+}
+
+describe('mineflayer_vehicle_physics 1.17.1v', function () {
+  this.timeout(10 * 1000)
+
+  const supportedVersion = '1.17.1'
+  const registry = require('prismarine-registry')(supportedVersion)
+  let bot
+  let server
+
+  beforeEach((done) => {
+    server = mc.createServer({
+      'online-mode': false,
+      version: supportedVersion,
+      port: 25569
+    })
+    server.on('listening', () => {
+      bot = mineflayer.createBot({
+        username: 'player',
+        version: supportedVersion,
+        port: 25569
+      })
+      bot.test = {}
+      bot.test.generateLoginPacket = () => {
+        const loginPacket = registry.loginPacket
+        loginPacket.entityId = 0
+        return loginPacket
+      }
+      done()
+    })
+  })
+
+  afterEach((done) => {
+    teardownBotAndServer(bot, server, done)
+  })
+
+  it('creates boatCtx for the first passenger', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+        assert(bot._boatPhysics.getCtx(), 'expected boat physics context')
+        assert.strictEqual(bot._boatPhysics.getCtx().state.constructor.name, 'BoatState')
+      })
+    })
+  })
+
+  it('does not control or send movement packets for the second passenger', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const vehicleId = 100
+        const boat = setupBoat(bot, vehicleId, vec3(0, 63, 0))
+        bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [200, bot.entity.id] })
+        assert.strictEqual(bot.vehicle?.id, vehicleId)
+
+        const writes = captureWrites(bot)
+        bot.setControlState('forward', true)
+        await once(bot, 'physicsTick')
+        bot.setControlState('forward', false)
+
+        assertNoBoatCtx(bot)
+        assert.strictEqual(writes.filter(w => w.name === 'vehicle_move').length, 0)
+        assert.strictEqual(writes.filter(w => w.name === 'steer_boat').length, 0)
+        assert.strictEqual(boat.position.z, 0)
+      })
+    })
+  })
+
+  it('moves the boat forward and sends finite vehicle_move', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+        const writes = captureWrites(bot)
+        bot.setControlState('forward', true)
+        await once(bot, 'physicsTick')
+        bot.setControlState('forward', false)
+
+        const packet = writes.find(w => w.name === 'vehicle_move')
+        assert(packet, 'expected vehicle_move')
+        assert([packet.data.x, packet.data.y, packet.data.z, packet.data.yaw, packet.data.pitch].every(Number.isFinite))
+        assert.ok(boat.position.z < 0, 'boat should move forward in -z')
+      })
+    })
+  })
+
+  it('sends vehicle yaw/pitch in protocol degrees', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+        boat.yaw = Math.PI / 4
+        boat.pitch = -Math.PI / 6
+        bot._boatPhysics.getCtx()?.state.rebaseFromEntity(boat)
+
+        const writes = captureWrites(bot)
+        await once(bot, 'physicsTick')
+
+        const packet = writes.find(w => w.name === 'vehicle_move')
+        assert(packet, 'expected vehicle_move')
+        assert.ok(Math.abs(packet.data.yaw) > 10, 'yaw should be in degrees')
+        assert.ok(Math.abs(packet.data.pitch) > 5, 'pitch should be in degrees')
+        assert.ok(Math.abs(packet.data.yaw) <= 360)
+      })
+    })
+  })
+
+  it('maps paddle states from controls', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupBoat(bot, 100, vec3(0, 63, 0))
+
+        async function paddlesFor (controls) {
+          bot.clearControlStates()
+          for (const [control, state] of Object.entries(controls)) {
+            bot.setControlState(control, state)
+          }
+          const writes = captureWrites(bot)
+          await once(bot, 'physicsTick')
+          bot.clearControlStates()
+          return writes.find(w => w.name === 'steer_boat')?.data
+        }
+
+        assert.deepStrictEqual(await paddlesFor({ forward: true }), { leftPaddle: true, rightPaddle: true })
+        assert.deepStrictEqual(await paddlesFor({ back: true }), { leftPaddle: false, rightPaddle: false })
+        assert.deepStrictEqual(await paddlesFor({ left: true }), { leftPaddle: false, rightPaddle: true })
+        assert.deepStrictEqual(await paddlesFor({ right: true }), { leftPaddle: true, rightPaddle: false })
+      })
+    })
+  })
+
+  it('does not mutate the boat or send prediction when worldReady is false', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+        stubUnloadedWorld(bot)
+
+        const before = {
+          x: boat.position.x,
+          y: boat.position.y,
+          z: boat.position.z,
+          yaw: boat.yaw
+        }
+        const writes = captureWrites(bot)
+        await once(bot, 'physicsTick')
+
+        assert.strictEqual(bot._boatPhysics.getCtx().state.worldReady, false)
+        assert.strictEqual(boat.position.x, before.x)
+        assert.strictEqual(boat.position.y, before.y)
+        assert.strictEqual(boat.position.z, before.z)
+        assert.strictEqual(boat.yaw, before.yaw)
+        assert.strictEqual(writes.filter(w => w.name === 'vehicle_move').length, 0)
+      })
+    })
+  })
+
+  it('rebases on vehicle_move correction and confirms immediately', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+
+        const writes = captureWrites(bot)
+        bot._client.emit('vehicle_move', { x: 5, y: 62, z: -3, yaw: 45, pitch: 10 })
+        await once(bot, 'physicsTick')
+
+        const confirm = writes.find(w => w.name === 'vehicle_move')
+        assert(confirm, 'expected confirm vehicle_move')
+        assert.strictEqual(confirm.data.x, 5)
+        assert.strictEqual(confirm.data.y, 62)
+        assert.strictEqual(confirm.data.z, -3)
+        assert.strictEqual(confirm.data.yaw, 45)
+        assert.ok(Math.abs(boat.position.x - 5) < 0.5, 'boat x should rebase toward server correction')
+      })
+    })
+  })
+
+  it('replaces velocity on entity_velocity correction', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+
+        bot._client.emit('entity_velocity', {
+          entityId: 100,
+          velocityX: 8000,
+          velocityY: 0,
+          velocityZ: -8000
+        })
+        assert.strictEqual(boat.velocity.x, 1)
+        assert.strictEqual(boat.velocity.z, -1)
+
+        await once(bot, 'physicsTick')
+        assert(bot._boatPhysics.getCtx(), 'boat ctx should remain after velocity correction')
+      })
+    })
+  })
+
+  it('preserves yawVelocity across teleport and relative move corrections', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+        const ctx = bot._boatPhysics.getCtx()
+        ctx.state.yawVelocity = 0.05
+
+        bot._client.emit('entity_teleport', {
+          entityId: 100,
+          x: 1,
+          y: 63,
+          z: 1,
+          yaw: 90,
+          pitch: 0
+        })
+        await once(bot, 'physicsTick')
+        assert.ok(ctx.state.yawVelocity > 0, 'yawVelocity must not be cleared by teleport rebase')
+
+        bot._client.emit('rel_entity_move', {
+          entityId: 100,
+          dX: 32,
+          dY: 0,
+          dZ: 0
+        })
+        await once(bot, 'physicsTick')
+        assert.ok(ctx.state.yawVelocity > 0, 'yawVelocity must not be cleared by relative move rebase')
+      })
+    })
+  })
+
+  it('emits entityMoved for the vehicle once per successful tick', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+
+        const violations = []
+        let movedThisTick = 0
+        bot.on('entityMoved', (entity) => {
+          if (entity === boat) movedThisTick++
+        })
+        bot.on('physicsTick', () => {
+          if (movedThisTick > 1) violations.push(movedThisTick)
+          movedThisTick = 0
+        })
+
+        for (let i = 0; i < 5; i++) {
+          await once(bot, 'physicsTick')
+        }
+
+        assert.strictEqual(violations.length, 0, `entityMoved fired ${violations[0]} times in one physics tick`)
+      })
+    })
+  })
+
+  it('destroys boatCtx on dismount, entityGone, and respawn', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+        assert(bot._boatPhysics.getCtx())
+
+        bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+        assertNoBoatCtx(bot)
+
+        setupBoat(bot, 101, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+        bot._client.emit('entity_destroy', { entityIds: [101] })
+        assertNoBoatCtx(bot)
+
+        setupBoat(bot, 102, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+        bot.emit('respawn')
+        assertNoBoatCtx(bot)
+      })
+    })
+  })
+
+  it('restores normal player physics after dismount', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+        bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+
+        const before = bot.entity.position.clone()
+        bot.setControlState('forward', true)
+        await once(bot, 'physicsTick')
+        await once(bot, 'physicsTick')
+        bot.setControlState('forward', false)
+
+        const moved = (bot.entity.position.x - before.x) ** 2 + (bot.entity.position.z - before.z) ** 2
+        assert.ok(moved > 1e-8, 'player should move after dismount')
+      })
+    })
+  })
+
+  it('disables local boat physics after three rapid corrections until remount', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+
+        const writes = captureWrites(bot)
+        for (let i = 0; i < 3; i++) {
+          bot._client.emit('vehicle_move', { x: i, y: 63, z: 0, yaw: 0, pitch: 0 })
+        }
+        await once(bot, 'physicsTick')
+        assert.strictEqual(bot._boatPhysics.isDisabled(), true)
+
+        const predictionPackets = writes.filter(w => w.name === 'vehicle_move')
+        assert.strictEqual(predictionPackets.length, 3, 'confirm packets only from corrections')
+
+        bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+        await once(bot, 'physicsTick')
+        setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+        assert.strictEqual(bot._boatPhysics.isDisabled(), false)
+      })
+    })
+  })
+})
+
+describe('mineflayer_vehicle_physics legacy boat behavior', function () {
+  this.timeout(10 * 1000)
+
+  const supportedVersion = '1.18.2'
+  const registry = require('prismarine-registry')(supportedVersion)
+  let bot
+  let server
+
+  beforeEach((done) => {
+    server = mc.createServer({
+      'online-mode': false,
+      version: supportedVersion,
+      port: 25570
+    })
+    server.on('listening', () => {
+      bot = mineflayer.createBot({
+        username: 'player',
+        version: supportedVersion,
+        port: 25570
+      })
+      bot.test = {}
+      bot.test.generateLoginPacket = () => {
+        const loginPacket = registry.loginPacket
+        loginPacket.entityId = 0
+        return loginPacket
+      }
+      done()
+    })
+  })
+
+  afterEach((done) => {
+    teardownBotAndServer(bot, server, done)
+  })
+
+  it('keeps legacy vehicle_move behavior on non-1.17.1 versions', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        bot.blockAt = createBlockWorldStub(bot.version)
+        const boat = bot.entities[100] ?? { id: 100, passengers: [] }
+        boat.name = 'boat'
+        boat.position = vec3(0, 63, 0)
+        boat.width = 1.375
+        boat.height = 0.5625
+        boat.velocity = vec3(0, 0, 0)
+        boat.yaw = 0
+        boat.pitch = 0
+        bot.entities[100] = boat
+        bot._client.emit('set_passengers', { entityId: 100, passengers: [bot.entity.id] })
+
+        const writes = captureWrites(bot)
+        await once(bot, 'physicsTick')
+
+        assertNoBoatCtx(bot, 'legacy versions must not create boatCtx')
+        assert.ok(writes.some(w => w.name === 'vehicle_move'))
+        assert.ok(writes.some(w => w.name === 'steer_boat'))
+      })
+    })
+  })
+})

--- a/test/vehiclePhysicsTest.js
+++ b/test/vehiclePhysicsTest.js
@@ -165,6 +165,7 @@ describe('mineflayer_vehicle_physics 1.17.1v', function () {
         await once(bot, 'physicsTick')
         assert(bot._boatPhysics.getCtx(), 'expected boat physics context')
         assert.strictEqual(bot._boatPhysics.getCtx().state.constructor.name, 'BoatState')
+        assert.notStrictEqual(bot._boatPhysics.getStatus(), null)
       })
     })
   })

--- a/test/vehiclePhysicsTest.js
+++ b/test/vehiclePhysicsTest.js
@@ -289,6 +289,41 @@ describe('mineflayer_vehicle_physics 1.17.1v', function () {
     })
   })
 
+  it('exposes getPaddleState from boat physics context', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        assert.strictEqual(bot._boatPhysics.getPaddleState(), null)
+
+        stubLoadedWorld(bot)
+        setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+
+        bot.setControlState('forward', true)
+        await once(bot, 'physicsTick')
+        assert.deepStrictEqual(bot._boatPhysics.getPaddleState(), { leftPaddle: true, rightPaddle: true })
+
+        bot.clearControlStates()
+        bot.setControlState('back', true)
+        await once(bot, 'physicsTick')
+        assert.deepStrictEqual(bot._boatPhysics.getPaddleState(), { leftPaddle: false, rightPaddle: false })
+
+        bot.clearControlStates()
+        bot.setControlState('left', true)
+        await once(bot, 'physicsTick')
+        assert.deepStrictEqual(bot._boatPhysics.getPaddleState(), { leftPaddle: false, rightPaddle: true })
+
+        bot.clearControlStates()
+        bot.setControlState('right', true)
+        await once(bot, 'physicsTick')
+        assert.deepStrictEqual(bot._boatPhysics.getPaddleState(), { leftPaddle: true, rightPaddle: false })
+
+        bot._client.emit('set_passengers', { entityId: 100, passengers: [] })
+        assert.strictEqual(bot._boatPhysics.getCtx(), null)
+        assert.strictEqual(bot._boatPhysics.getPaddleState(), null)
+      })
+    })
+  })
+
   it('does not mutate the boat or send prediction when worldReady is false', (done) => {
     server.on('playerJoin', (client) => {
       withLogin(bot, client, done, async () => {

--- a/test/vehiclePhysicsTest.js
+++ b/test/vehiclePhysicsTest.js
@@ -4,6 +4,7 @@ const mineflayer = require('../')
 const mc = require('minecraft-protocol')
 const vec3 = require('vec3')
 const assert = require('assert')
+const conv = require('../lib/conversions')
 const { once } = require('../lib/promise_utils')
 
 function createBlockWorldStub (version, waterSurfaceY = 63) {
@@ -120,8 +121,14 @@ function teardownBotAndServer (bot, server, done) {
 }
 
 function withLogin (bot, client, done, runTest) {
-  bot.once('login', () => {
-    runTest().then(() => done(), done)
+  bot.once('login', async () => {
+    try {
+      await once(bot, 'forcedMove')
+      await runTest()
+      done()
+    } catch (err) {
+      done(err)
+    }
   })
   loginBot(bot, client)
 }
@@ -594,6 +601,21 @@ describe('mineflayer_vehicle_physics 1.17.1v', function () {
     })
   })
 
+  it('emits entityPhysicsTick for controlled boat', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        setupBoat(bot, 100, vec3(0, 63, 0))
+
+        let entityPhysicsTicks = 0
+        bot.on('entityPhysicsTick', () => { entityPhysicsTicks++ })
+        await once(bot, 'physicsTick')
+
+        assert.ok(entityPhysicsTicks >= 1, 'expected entityPhysicsTick while controlling boat')
+      })
+    })
+  })
+
   it('disables local boat physics after three rapid corrections until remount', (done) => {
     server.on('playerJoin', (client) => {
       withLogin(bot, client, done, async () => {
@@ -655,11 +677,42 @@ describe('mineflayer_vehicle_physics legacy boat behavior', function () {
     teardownBotAndServer(bot, server, done)
   })
 
-  it('keeps legacy vehicle_move behavior on non-1.17.1 versions', (done) => {
+  it('receives physicsTick and sends legacy boat packets on 1.18.2', (done) => {
     server.on('playerJoin', (client) => {
       withLogin(bot, client, done, async () => {
         bot.blockAt = createBlockWorldStub(bot.version)
-        const boat = bot.entities[100] ?? { id: 100, passengers: [] }
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+        boat.yaw = Math.PI / 4
+        boat.pitch = -Math.PI / 6
+
+        const writes = captureWrites(bot)
+        let physicsTicks = 0
+        bot.on('physicsTick', () => { physicsTicks++ })
+        await once(bot, 'physicsTick')
+
+        assert.ok(physicsTicks >= 1, 'legacy boat controller should receive physicsTick')
+        assertNoBoatCtx(bot, 'legacy versions must not create boatCtx')
+        assert.ok(writes.some(w => w.name === 'vehicle_move'))
+        assert.ok(writes.some(w => w.name === 'steer_boat'))
+        assert.strictEqual(writes.filter(w => w.name === 'position').length, 0)
+        assert.strictEqual(writes.filter(w => w.name === 'position_look').length, 0)
+
+        const packet = writes.find(w => w.name === 'vehicle_move')
+        assert(packet, 'expected vehicle_move')
+        assert.ok(Math.abs(packet.data.yaw) > 10, 'yaw should be in notchian degrees, not radians')
+        assert.ok(Math.abs(packet.data.pitch) > 5, 'pitch should be in notchian degrees, not radians')
+        assert.ok(Math.abs(packet.data.yaw - conv.toNotchianYaw(boat.yaw)) < 0.01)
+        assert.ok(Math.abs(packet.data.pitch - conv.toNotchianPitch(boat.pitch)) < 0.01)
+      })
+    })
+  })
+
+  it('does not send legacy boat packets for the second passenger on 1.18.2', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        bot.blockAt = createBlockWorldStub(bot.version)
+        const vehicleId = 100
+        const boat = bot.entities[vehicleId] ?? { id: vehicleId, passengers: [] }
         boat.name = 'boat'
         boat.position = vec3(0, 63, 0)
         boat.width = 1.375
@@ -670,15 +723,49 @@ describe('mineflayer_vehicle_physics legacy boat behavior', function () {
         boat.metadata ??= []
         boat.effects ??= []
         boat.equipment ??= []
-        bot.entities[100] = boat
-        bot._client.emit('set_passengers', { entityId: 100, passengers: [bot.entity.id] })
+        bot.entities[vehicleId] = boat
+        bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [200, bot.entity.id] })
+        assert.strictEqual(bot.vehicle?.id, vehicleId)
 
         const writes = captureWrites(bot)
-        await once(bot, 'physicsTick')
+        bot.setControlState('forward', true)
+        await once(bot, 'physicsTickBegin')
+        bot.setControlState('forward', false)
 
-        assertNoBoatCtx(bot, 'legacy versions must not create boatCtx')
-        assert.ok(writes.some(w => w.name === 'vehicle_move'))
-        assert.ok(writes.some(w => w.name === 'steer_boat'))
+        assertNoBoatCtx(bot)
+        assert.strictEqual(writes.filter(w => w.name === 'vehicle_move').length, 0)
+        assert.strictEqual(writes.filter(w => w.name === 'steer_boat').length, 0)
+      })
+    })
+  })
+
+  it('pauses physics for unsupported non-boat mounts on 1.18.2', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        bot.blockAt = createBlockWorldStub(bot.version)
+        const pig = bot.entities[100] ?? { id: 100, passengers: [] }
+        pig.name = 'pig'
+        pig.position = vec3(0, 64, 0)
+        pig.width = 0.9
+        pig.height = 0.9
+        pig.velocity = vec3(0, 0, 0)
+        pig.yaw = 0
+        pig.pitch = 0
+        pig.metadata ??= []
+        pig.effects ??= []
+        pig.equipment ??= []
+        bot.entities[100] = pig
+        bot._client.emit('set_passengers', { entityId: 100, passengers: [bot.entity.id] })
+
+        let physicsTicks = 0
+        bot.on('physicsTick', () => { physicsTicks++ })
+        const writes = captureWrites(bot)
+        await once(bot, 'physicsTickBegin')
+
+        assert.strictEqual(physicsTicks, 0, 'unsupported mount should pause physicsTick')
+        assert.strictEqual(writes.filter(w => w.name === 'vehicle_move').length, 0)
+        assert.strictEqual(writes.filter(w => w.name === 'position').length, 0)
+        assert.strictEqual(writes.filter(w => w.name === 'position_look').length, 0)
       })
     })
   })

--- a/test/vehiclePhysicsTest.js
+++ b/test/vehiclePhysicsTest.js
@@ -169,6 +169,29 @@ describe('mineflayer_vehicle_physics 1.17.1v', function () {
     })
   })
 
+  it('controls boat when passengers[0] is a duplicate entity object with the same id', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+
+        const stalePassengerRef = { id: bot.entity.id, vehicle: boat }
+        boat.passengers[0] = stalePassengerRef
+        assert.notStrictEqual(boat.passengers[0], bot.entity)
+        assert.strictEqual(boat.passengers[0].id, bot.entity.id)
+
+        const beforeZ = boat.position.z
+        bot.setControlState('forward', true)
+        await once(bot, 'physicsTick')
+        bot.setControlState('forward', false)
+
+        assert(bot._boatPhysics.getCtx(), 'expected boat physics context for matching passenger id')
+        assert.ok(boat.position.z < beforeZ, 'boat should move when id matches despite stale object reference')
+      })
+    })
+  })
+
   it('does not control or send movement packets for the second passenger', (done) => {
     server.on('playerJoin', (client) => {
       withLogin(bot, client, done, async () => {

--- a/test/vehiclePhysicsTest.js
+++ b/test/vehiclePhysicsTest.js
@@ -79,6 +79,9 @@ function setupBoat (bot, vehicleId, position) {
   boat.velocity = vec3(0, 0, 0)
   boat.yaw = 0
   boat.pitch = 0
+  boat.metadata ??= []
+  boat.effects ??= []
+  boat.equipment ??= []
   bot.entities[vehicleId] = boat
   bot._client.emit('set_passengers', { entityId: vehicleId, passengers: [bot.entity.id] })
   return boat
@@ -118,7 +121,7 @@ function teardownBotAndServer (bot, server, done) {
 
 function withLogin (bot, client, done, runTest) {
   bot.once('login', () => {
-    void runTest().then(() => done(), done)
+    runTest().then(() => done(), done)
   })
   loginBot(bot, client)
 }
@@ -398,6 +401,9 @@ describe('mineflayer_vehicle_physics 1.17.1v', function () {
         boat.velocity = vec3(0, 0, 0)
         boat.yaw = 0
         boat.pitch = 0
+        boat.metadata ??= []
+        boat.effects ??= []
+        boat.equipment ??= []
         bot.entities[100] = boat
 
         let movedEvents = 0
@@ -661,6 +667,9 @@ describe('mineflayer_vehicle_physics legacy boat behavior', function () {
         boat.velocity = vec3(0, 0, 0)
         boat.yaw = 0
         boat.pitch = 0
+        boat.metadata ??= []
+        boat.effects ??= []
+        boat.equipment ??= []
         bot.entities[100] = boat
         bot._client.emit('set_passengers', { entityId: 100, passengers: [bot.entity.id] })
 

--- a/test/vehiclePhysicsTest.js
+++ b/test/vehiclePhysicsTest.js
@@ -303,6 +303,124 @@ describe('mineflayer_vehicle_physics 1.17.1v', function () {
     })
   })
 
+  it('ignores routine server broadcasts for the controlled boat', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+
+        const before = {
+          x: boat.position.x,
+          y: boat.position.y,
+          z: boat.position.z,
+          yaw: boat.yaw,
+          velX: boat.velocity.x,
+          velZ: boat.velocity.z
+        }
+        let movedEvents = 0
+        bot.on('entityMoved', (entity) => {
+          if (entity === boat) movedEvents++
+        })
+
+        bot._client.emit('rel_entity_move', { entityId: 100, dX: 32, dY: 0, dZ: 0 })
+        bot._client.emit('entity_move_look', { entityId: 100, dX: 0, dY: 0, dZ: -32, yaw: 90, pitch: 0 })
+        bot._client.emit('entity_look', { entityId: 100, yaw: 45, pitch: 10 })
+        bot._client.emit('entity_velocity', { entityId: 100, velocityX: 8000, velocityY: 0, velocityZ: -8000 })
+
+        assert.strictEqual(boat.position.x, before.x)
+        assert.strictEqual(boat.position.y, before.y)
+        assert.strictEqual(boat.position.z, before.z)
+        assert.strictEqual(boat.yaw, before.yaw)
+        assert.strictEqual(boat.velocity.x, before.velX)
+        assert.strictEqual(boat.velocity.z, before.velZ)
+        assert.strictEqual(movedEvents, 0)
+      })
+    })
+  })
+
+  it('ignores entity_teleport for the controlled boat even with a large delta', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+        const ctx = bot._boatPhysics.getCtx()
+        ctx.state.yawVelocity = 0.05
+
+        let movedFromTeleport = 0
+        let correctionEvents = 0
+        const onMoved = (entity) => {
+          if (entity === boat) movedFromTeleport++
+        }
+        const onCorrection = (entity) => {
+          if (entity === boat) correctionEvents++
+        }
+        bot.on('entityMoved', onMoved)
+        bot.on('vehicleCorrection', onCorrection)
+
+        bot._client.emit('entity_teleport', {
+          entityId: 100,
+          x: 5,
+          y: 63,
+          z: 3,
+          yaw: 90,
+          pitch: 0
+        })
+
+        assert.strictEqual(boat.position.x, 0)
+        assert.strictEqual(boat.position.z, 0)
+        assert.strictEqual(movedFromTeleport, 0)
+        assert.strictEqual(correctionEvents, 0)
+        bot.removeListener('entityMoved', onMoved)
+        bot.removeListener('vehicleCorrection', onCorrection)
+
+        await once(bot, 'physicsTick')
+
+        assert.ok(Math.abs(boat.position.x - 5) > 0.5, 'entity_teleport must not move controlled boat')
+        assert.ok(Math.abs(boat.position.z - 3) > 0.5, 'entity_teleport must not move controlled boat')
+        assert.ok(ctx.state.yawVelocity > 0)
+        assert.ok(Math.abs(ctx.state.pos.x) < 0.5)
+      })
+    })
+  })
+
+  it('applies entity_teleport to boats the bot is not controlling', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const boat = bot.entities[100] ?? { id: 100 }
+        boat.name = 'boat'
+        boat.position = vec3(0, 63, 0)
+        boat.width = 1.375
+        boat.height = 0.5625
+        boat.velocity = vec3(0, 0, 0)
+        boat.yaw = 0
+        boat.pitch = 0
+        bot.entities[100] = boat
+
+        let movedEvents = 0
+        bot.on('entityMoved', (entity) => {
+          if (entity === boat) movedEvents++
+        })
+
+        bot._client.emit('entity_teleport', {
+          entityId: 100,
+          x: 5,
+          y: 63,
+          z: 3,
+          yaw: 90,
+          pitch: 0
+        })
+
+        assert.ok(Math.abs(boat.position.x - 5) < 0.01)
+        assert.ok(Math.abs(boat.position.z - 3) < 0.01)
+        assert.strictEqual(movedEvents, 1)
+        assertNoBoatCtx(bot)
+      })
+    })
+  })
+
   it('rebases on vehicle_move correction and confirms immediately', (done) => {
     server.on('playerJoin', (client) => {
       withLogin(bot, client, done, async () => {
@@ -325,7 +443,33 @@ describe('mineflayer_vehicle_physics 1.17.1v', function () {
     })
   })
 
-  it('replaces velocity on entity_velocity correction', (done) => {
+  it('does not ping-pong after vehicle_move when routine broadcasts arrive', (done) => {
+    server.on('playerJoin', (client) => {
+      withLogin(bot, client, done, async () => {
+        stubLoadedWorld(bot)
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+
+        bot._client.emit('vehicle_move', { x: 5, y: 62, z: -3, yaw: 45, pitch: 10 })
+        await once(bot, 'physicsTick')
+
+        const afterCorrection = { x: boat.position.x, z: boat.position.z }
+        bot._client.emit('rel_entity_move', { entityId: 100, dX: -32, dY: 0, dZ: 32 })
+        bot._client.emit('entity_move_look', { entityId: 100, dX: 16, dY: 0, dZ: -16, yaw: 10, pitch: 0 })
+        await once(bot, 'physicsTick')
+
+        assert.ok(Math.abs(boat.position.x - afterCorrection.x) < 0.01)
+        assert.ok(Math.abs(boat.position.z - afterCorrection.z) < 0.01)
+        assert.ok(Math.abs(ctxOrBoatPos(bot) - 5) < 0.5)
+      })
+    })
+  })
+
+  function ctxOrBoatPos (bot) {
+    return bot._boatPhysics.getCtx()?.state?.pos?.x ?? bot.vehicle.position.x
+  }
+
+  it('ignores entity_velocity for the controlled boat', (done) => {
     server.on('playerJoin', (client) => {
       withLogin(bot, client, done, async () => {
         stubLoadedWorld(bot)
@@ -338,34 +482,28 @@ describe('mineflayer_vehicle_physics 1.17.1v', function () {
           velocityY: 0,
           velocityZ: -8000
         })
-        assert.strictEqual(boat.velocity.x, 1)
-        assert.strictEqual(boat.velocity.z, -1)
+        assert.strictEqual(boat.velocity.x, 0)
+        assert.strictEqual(boat.velocity.z, 0)
 
         await once(bot, 'physicsTick')
-        assert(bot._boatPhysics.getCtx(), 'boat ctx should remain after velocity correction')
+        assert(bot._boatPhysics.getCtx(), 'boat ctx should remain')
       })
     })
   })
 
-  it('preserves yawVelocity across teleport and relative move corrections', (done) => {
+  it('preserves yawVelocity across vehicle_move while ignoring relative move', (done) => {
     server.on('playerJoin', (client) => {
       withLogin(bot, client, done, async () => {
         stubLoadedWorld(bot)
-        setupBoat(bot, 100, vec3(0, 63, 0))
+        const boat = setupBoat(bot, 100, vec3(0, 63, 0))
         await once(bot, 'physicsTick')
         const ctx = bot._boatPhysics.getCtx()
         ctx.state.yawVelocity = 0.05
 
-        bot._client.emit('entity_teleport', {
-          entityId: 100,
-          x: 1,
-          y: 63,
-          z: 1,
-          yaw: 90,
-          pitch: 0
-        })
+        bot._client.emit('vehicle_move', { x: 5, y: 63, z: 3, yaw: 45, pitch: 10 })
         await once(bot, 'physicsTick')
-        assert.ok(ctx.state.yawVelocity > 0, 'yawVelocity must not be cleared by teleport rebase')
+        assert.ok(Math.abs(boat.position.x - 5) < 0.01, 'vehicle_move should rebase controlled boat')
+        assert.ok(ctx.state.yawVelocity > 0, 'yawVelocity must not be cleared by vehicle_move rebase')
 
         bot._client.emit('rel_entity_move', {
           entityId: 100,
@@ -374,7 +512,8 @@ describe('mineflayer_vehicle_physics 1.17.1v', function () {
           dZ: 0
         })
         await once(bot, 'physicsTick')
-        assert.ok(ctx.state.yawVelocity > 0, 'yawVelocity must not be cleared by relative move rebase')
+        assert.ok(Math.abs(boat.position.x - 5) < 0.01, 'relative move must not mutate controlled boat')
+        assert.ok(ctx.state.yawVelocity > 0, 'yawVelocity must not be cleared by ignored relative move')
       })
     })
   })


### PR DESCRIPTION
## Add locally predicted boat and horse control, plus server-authoritative minecart riding

### Context

Mineflayer previously treated mounted entities as server-driven objects. That is
insufficient for responsive vehicle control: a controlling passenger of a boat or
a horse must simulate movement locally, send input/paddle state, and reconcile
authoritative server corrections. Minecarts, by contrast, are driven entirely by
the server and only need the rider to follow along accurately.

### Root causes addressed

- Passenger lifecycle relied on local assumptions instead of authoritative
  `set_passengers` packets.
- Duplicate entity objects could prevent controller detection when passenger
  identity was compared by object reference.
- Routine entity broadcasts could overwrite locally predicted vehicle movement
  and cause visible jitter.
- Player and vehicle state could diverge during acceleration.
- Correction packets needed explicit acknowledgement and simulation rebasing.
- Remote (non-controlled) vehicles and their passengers were not observed
  correctly (attach events and rider look/rotation).

### Implementation

**Shared**

- Make `set_passengers` authoritative for mount and dismount state.
- Detect the controlling passenger by entity ID.
- Keep the player synchronized with its current vehicle.
- Ignore routine relative movement, teleport, and velocity broadcasts for
  locally controlled vehicles.
- Expose `bot.vehicle`, `bot.moveVehicle(left, forward, jump)`, and a
  `vehicleCorrection` event; expose boat/horse physics status for rendering
  integration.

**Boats (locally predicted, 1.17.1)**

- Create and clean up a `BoatPhysics` context for controlled boats.
- Map Mineflayer controls to boat steering and paddle state.
- Simulate controlled boats each physics tick and send finite `vehicle_move`
  updates using protocol-degree yaw/pitch.
- Accept authoritative `vehicle_move` corrections, rebase simulation, and
  acknowledge them immediately.
- Disable local boat prediction after repeated rapid corrections.

**Horses (locally predicted, 1.17.1)**

- Create and clean up a `HorsePhysics` context for saddled, ridden horses.
- Gate control on saddle flag and controlling-passenger ID.
- Simulate rider input (movement + jump charge) each tick, send updates, and
  reconcile `vehicle_move` corrections the same way as boats, including the
  correction-limit safeguard and attribute updates.

**Minecarts (server-authoritative, any version)**

- Follow the server-driven minecart position via `entityMoved` and keep the
  rider in sync; no local simulation is performed.

**Observation**

- Emit attach events for remote vehicle passengers and handle rider look /
  rotation so other players' vehicles are observed correctly.

- Preserve existing behavior for unsupported and legacy protocol versions.

### Testing

- `npx mocha test/vehiclePhysicsTest.js` — 19 passing.
- Regression suites added:
  - `vehiclePhysicsTest.js` / `vehicleLifecycleTest.js` — boat movement, paddle
    packets, corrections, mount/dismount, duplicate passengers, first- vs
    second-passenger control, cleanup on dismount/removal/respawn, fallback to
    normal player physics, legacy behavior.
  - `horsePhysicsTest.js` / `horseLifecycleTest.js` / `entityPhysicsHorseTest.js`
    — horse rider input, jump charge, corrections, lifecycle, and horse entity
    physics (including non-1.17.1 versions).
  - `minecartLifecycleTest.js` — server-authoritative minecart mount, sync, and
    dismount.
  - `entityLookTest.js` — remote passenger look / rotation observation.

### Related PRs

- Depends on [nxg-org/mineflayer-physics-utils#56](https://github.com/nxg-org/mineflayer-physics-utils/pull/56).
- Consumed by [zardoy/minecraft-web-client#590](https://github.com/zardoy/minecraft-web-client/pull/590).
- Visual behavior is implemented by [zardoy/minecraft-renderer#85](https://github.com/zardoy/minecraft-renderer/pull/85).

### Scope

Local prediction is enabled only for the explicitly supported Minecraft 1.17.1
boat and horse paths; other protocol versions retain their previous behavior for
these. Minecart riding is server-authoritative and version-neutral.

**Why 1.17.1 only (for now):** the limit comes from the boat path, not from a
general design constraint:

- *Boat protocol/input handling* — paddle state is sent with `steer_boat`,
  while mounted movement input uses `steer_vehicle` on older versions and the
  unified `player_input` on 1.21.3+. Although `vehicle_move` remains available,
  supporting additional versions still requires version-aware input handling
  and validation.
- *Boat physics model* — the simulation reproduces 1.17.1 water/buoyancy
  behavior, which vanilla changed across versions, so it would drift elsewhere.
- *Horse* — the horse simulation itself matches current (1.21.x) vanilla and is
  not inherently tied to 1.17.1; it is gated to 1.17.1 only because it shares the
  same version-locked correction plumbing as the boat and was validated there.

Broadening version support is a follow-up: it requires version-aware input
handling, plus per-version validation of boat physics and correction behavior.
Minecart riding already works across versions because it is
server-authoritative.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local physics support for controlling boats and saddled horses on Minecraft 1.17.1.
  * Improved vehicle movement, steering, jumping, mounting, and dismounting behavior.
  * Added synchronization for passengers transferring between vehicles.
  * Added vehicle state access through the bot API and optional jump control for `moveVehicle`.

* **Bug Fixes**
  * Prevented conflicting server updates from overriding locally controlled vehicles.
  * Improved dismount positioning and minecart lifecycle handling.
  * Preserved correct entity rotation updates when packet values are zero or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->