### PR TITLE
fix(vehicles): send real steering input while riding

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -1244,24 +1244,31 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     bot.emit('move', oldPos)
   }
 
+  function clampVehicleMoveComponent (value) {
+    const number = Number.isFinite(value) ? value : 0
+    return Math.min(Math.abs(number), MAX_VEHICLE_MOVE_COMPONENT) * Math.sign(number)
+  }
+
+  // Input channel only for versions without player_input (< 1.21.3).
+  //
+  // On 1.21.3+ updatePosition() already sends the full player_input (including
+  // jump/shift/sprint) whenever input changes — matching vanilla LocalPlayer. A
+  // second, reduced packet from here would clear those flags and the server would
+  // keep them cleared until the next controlState change, because
+  // lastSent.previousInputState already matches controlState.
+  //
+  // bot.vehicleMove is an internal one-tick legacy override; it is not supported on
+  // 1.21.3+.
   function sendPacketSteerVehicle () {
-    bot.vehicleMove ??= {
-      forward: bot.controlState.forward ? 1 : bot.controlState.back ? -1 : 0,
-      sideways: bot.controlState.left ? 1 : bot.controlState.right ? -1 : 0,
-      jump: bot.controlState.jump ? 1 : 0
-    }
+    const override = bot.vehicleMove
+    bot.vehicleMove = null
+    if (bot.supportFeature('newPlayerInputPacket')) return
 
-    for (const key of Object.keys(bot.vehicleMove)) {
-      bot.vehicleMove[key] = Math.min(Math.abs(bot.vehicleMove[key]), MAX_VEHICLE_MOVE_COMPONENT) * Math.sign(bot.vehicleMove[key])
-    }
+    const forward = override ? override.forward : (controlState.forward ? 1 : controlState.back ? -1 : 0)
+    const sideways = override ? override.sideways : (controlState.left ? 1 : controlState.right ? -1 : 0)
+    const jump = override ? override.jump : controlState.jump
 
-    bot.moveVehicle(bot.vehicleMove.sideways, bot.vehicleMove.forward, bot.vehicleMove.jump)
-
-    bot.vehicleMove = {
-      sideways: 0,
-      forward: 0,
-      jump: 0
-    }
+    bot.moveVehicle(clampVehicleMoveComponent(sideways), clampVehicleMoveComponent(forward), !!jump)
   }
 
   function sendPacketVehicleMove () {

--- a/test/minecartLifecycleTest.js
+++ b/test/minecartLifecycleTest.js
@@ -16,6 +16,8 @@ const MINECART_VARIANTS = [
   'command_block_minecart'
 ]
 
+const MAX_VEHICLE_MOVE_COMPONENT = 0.9800000190734863
+
 function captureWrites (bot) {
   const writes = []
   const oldWrite = bot._client.write
@@ -270,6 +272,45 @@ describe('mineflayer_minecart_lifecycle 1.17.1v', function () {
 
         assert.strictEqual(writes.filter(w => w.name === 'vehicle_move').length, 0)
         assert.ok(writes.some(w => w.name === 'steer_vehicle'), 'expected steer_vehicle packets')
+        done()
+      })
+      loginBot(bot, client, registry)
+    })
+  })
+
+  it('sends non-zero steer_vehicle input from controlState on every physics tick', (done) => {
+    server.on('playerJoin', (client) => {
+      bot.once('login', async () => {
+        stubLoadedWorld(bot)
+        await completeLoginHandshake(bot)
+
+        setupMinecart(bot, 100, 'minecart', vec3(0, 63, 0))
+        await once(bot, 'physicsTick')
+
+        const writes = captureWrites(bot)
+
+        bot.setControlState('forward', true)
+        for (let i = 0; i < 3; i++) {
+          await once(bot, 'physicsTick')
+        }
+
+        const forwardPackets = writes.filter(w => w.name === 'steer_vehicle')
+        assert.ok(forwardPackets.length >= 3, 'expected steer_vehicle on each physics tick')
+        for (const packet of forwardPackets) {
+          assert.strictEqual(packet.data.forward, MAX_VEHICLE_MOVE_COMPONENT, 'forward must be the clamped impulse while W is held')
+          assert.strictEqual(packet.data.sideways, 0)
+        }
+
+        bot.setControlState('forward', false)
+        bot.setControlState('left', true)
+        await once(bot, 'physicsTick')
+
+        const lastPacket = writes.filter(w => w.name === 'steer_vehicle').at(-1)
+        assert(lastPacket, 'expected steer_vehicle after switching to left')
+        assert.strictEqual(lastPacket.data.forward, 0)
+        assert.strictEqual(lastPacket.data.sideways, MAX_VEHICLE_MOVE_COMPONENT, 'left must produce the clamped positive sideways impulse')
+
+        bot.clearControlStates()
         done()
       })
       loginBot(bot, client, registry)

--- a/test/vehicleLifecycleTest.js
+++ b/test/vehicleLifecycleTest.js
@@ -353,6 +353,44 @@ for (const supportedVersion of mineflayer.testedVersions) {
             loginBot(client)
           })
         })
+
+        it('sends player_input once on input change while riding minecart', (done) => {
+          server.on('playerJoin', (client) => {
+            bot.once('login', async () => {
+              stubPassableWorld()
+              await once(bot, 'forcedMove')
+              await once(bot, 'physicsTick')
+
+              setupMinecart(100, vec3(0, 63, 0))
+              await once(bot, 'physicsTick')
+
+              const writes = captureWrites()
+
+              bot.setControlState('forward', true)
+              for (let i = 0; i < 3; i++) {
+                await once(bot, 'physicsTick')
+              }
+
+              const inputPackets = writes.filter(w => w.name === 'player_input')
+              assert.strictEqual(inputPackets.length, 1, 'player_input must be sent only on input change')
+              assert.strictEqual(inputPackets[0].data.inputs.forward, true)
+
+              const countAfterForward = inputPackets.length
+              for (let i = 0; i < 3; i++) {
+                await once(bot, 'physicsTick')
+              }
+              assert.strictEqual(
+                writes.filter(w => w.name === 'player_input').length,
+                countAfterForward,
+                'holding forward must not emit extra player_input packets'
+              )
+
+              bot.clearControlStates()
+              done()
+            })
+            loginBot(client)
+          })
+        })
       }
 
       it('preserves the existing horse passenger sync behavior', (done) => {


### PR DESCRIPTION
### Problem

Sitting in a minecart and holding W did nothing. Pushing the cart by hand, powered rails
and slopes worked fine, which is why this went unnoticed — those paths do not depend on
passenger steering input.

### Root cause

`sendPacketSteerVehicle()` reset `bot.vehicleMove` to a **truthy** zero object at the end of
every call:

```js
bot.vehicleMove ??= { forward: ..., sideways: ..., jump: ... }
...
bot.vehicleMove = { sideways: 0, forward: 0, jump: 0 }   // truthy!
```

`??=` only assigns on `null`/`undefined`, so from the second physics tick onward the steering
was never re-read from `controlState` again and the bot sent
`steer_vehicle { sideways: 0, forward: 0 }` forever. `bot.vehicleMove` is never set back to
`null` anywhere in the repo.

Why that stops the cart, in vanilla (verified against `MinecraftDeobfuscated-Mojang`, tag `1.17.1`):

* `client/player/LocalPlayer.java:196-203` — a passenger sends `ServerboundPlayerInputPacket`
  every tick.
* `server/network/ServerGamePacketListenerImpl.java:318-325` →
  `server/level/ServerPlayer.java:1016-1029` — those axes become the player's `xxa`/`zza`.
* `LivingEntity.aiStep()` → `travel()` gives the server-side riding player a real `deltaMovement`.
* `world/entity/vehicle/AbstractMinecart.java:445-454` — while the cart is slow
  (`horizontalDistanceSqr() < 0.01`) it gains `passengerDeltaMovement * 0.1` per tick.

With zeroed input the player's `deltaMovement` stays zero, so the nudge never fires and passenger
input cannot start a stationary cart; it requires external momentum from a push, powered rail or
slope. On 1.21.2+ the same thing is driven by `ServerPlayer.getLastClientMoveIntent()` with a
`0.001` impulse — same conclusion.

The bug came in with `1e61398c` (Mar 2025) and was masked for vehicle movement while every vehicle
also sent client-authoritative `vehicle_move`. `cedfe8aa` made `steer_vehicle` the only input
channel for minecarts, which is when it started to matter.

### Fix

* Derive steering from `controlState` on every tick; treat `bot.vehicleMove` as an internal
  one-shot override that is cleared after use.
* On 1.21.3+ (`newPlayerInputPacket`) skip this channel entirely. `updatePosition()` already
  sends the full `player_input` (including `jump`/`shift`/`sprint`) on every input change, exactly
  like vanilla. The second, reduced packet this function used to send cleared those flags — and
  they stayed cleared until the next `controlState` change, because `lastSent.previousInputState`
  already matched `controlState`.

The `0.9800000190734863` clamp is kept — it mirrors vanilla's `xxa *= 0.98F` in
`LivingEntity.aiStep()`. Sign convention of `moveVehicle(left, forward)` is unchanged.

### Tests

The existing minecart tests only asserted that a `steer_vehicle` packet was written, never its
contents — that is why this was not caught. Added assertions on the payload:

* 1.17.1 — every `steer_vehicle` across three consecutive ticks carries the held direction as the
  exact clamped impulse `0.9800000190734863`, and follows a change of controls.
* 1.21.4 — exactly one `player_input` per input change and none on unchanged ticks, pinning the
  "no second reduced packet" behaviour.

In both burst tests packet capture starts only after the baseline tick, so mount-time packets
cannot leak into the assertions.

### Manual check

Verified in-game: with the fix loaded, sitting in a stationary minecart on flat rails and holding
**W** accelerates it and keeps it moving — the reported case now works.

**A**/**D** were also verified in-game with the camera turned roughly 90° to the rail. The cart
moves in the expected direction; the camera angle matters because the impulse is yaw-relative.

### Follow-ups discovered during investigation

* `bot.dismount()` on 1.21.3+ writes `player_input { inputs: { jump: true } }`
  (`lib/plugins/entities.js:1243-1248`); vanilla 1.21.2+ dismounts on the **shift** bit.
* The `player_input` branch of `moveVehicle` never sets `jump`/`shift`/`sprint`
  (`entities.js:1223-1230`), so the legacy `0x01` jump and `0x02` unmount bits are dropped on 1.21.3+.
* Clientbound `move_minecart` (1.21.3+) has no handler. It is only sent when the server enables
  the `minecart_improvements` feature flag, which is off by default — so it does not affect this
  report. Supporting that feature flag will require a dedicated `move_minecart` handler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle and minecart steering responsiveness during physics updates.
  * Ensured movement inputs are clamped safely and one-time overrides are cleared after use.
  * Prevented redundant vehicle input packets while controls remain unchanged.
  * Improved compatibility across supported vehicle-control protocols.

* **Tests**
  * Added coverage for minecart steering, input transitions, and packet behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->